### PR TITLE
fix: address server actions review feedback

### DIFF
--- a/app/(dashboard)/analyses/actions.ts
+++ b/app/(dashboard)/analyses/actions.ts
@@ -30,9 +30,13 @@ import { revalidatePath } from "next/cache";
 export type AnalysisStatus = "pending" | "processing" | "completed" | "failed";
 
 /**
- * Risk level classification for clauses.
+ * Risk level classification for clauses (PRD-aligned taxonomy).
+ * - standard: Typical NDA terms, acceptable risk
+ * - cautious: Requires review, potentially unfavorable
+ * - aggressive: Significantly one-sided, legal review recommended
+ * - unknown: Unable to classify risk level
  */
-export type RiskLevel = "low" | "medium" | "high" | "critical";
+export type RiskLevel = "standard" | "cautious" | "aggressive" | "unknown";
 
 /**
  * Analysis record type inferred from schema with proper typing.
@@ -91,7 +95,7 @@ const getAnalysisClausesSchema = z.object({
   filters: z
     .object({
       category: z.string().optional(),
-      riskLevel: z.enum(["low", "medium", "high", "critical"]).optional(),
+      riskLevel: z.enum(["standard", "cautious", "aggressive", "unknown"]).optional(),
       minConfidence: z.number().min(0).max(1).optional(),
     })
     .optional(),

--- a/app/(dashboard)/documents/actions.ts
+++ b/app/(dashboard)/documents/actions.ts
@@ -12,7 +12,6 @@
 import { z } from "zod"
 import { withTenant } from "@/lib/dal"
 import { ok, err, type ApiResponse } from "@/lib/api-response"
-import { db } from "@/db"
 import { documents, documentChunks } from "@/db/schema"
 import { eq, and, isNull, ilike, desc, sql, count, isNotNull } from "drizzle-orm"
 import { uploadFile, deleteFile, computeContentHash } from "@/lib/blob"
@@ -136,7 +135,7 @@ function extractTitleFromFilename(fileName: string): string {
 export async function uploadDocument(
   formData: FormData
 ): Promise<ApiResponse<Document>> {
-  const { db: _db, tenantId, userId } = await withTenant()
+  const { db, tenantId, userId } = await withTenant()
 
   // Extract form data
   const file = formData.get("file")
@@ -246,7 +245,7 @@ export async function uploadDocument(
 export async function getDocuments(
   input: z.input<typeof getDocumentsInputSchema> = {}
 ): Promise<ApiResponse<Document[]>> {
-  const { tenantId } = await withTenant()
+  const { db, tenantId } = await withTenant()
 
   const parsed = getDocumentsInputSchema.safeParse(input)
   if (!parsed.success) {
@@ -298,7 +297,7 @@ export async function getDocuments(
 export async function searchDocuments(
   input: z.infer<typeof searchDocumentsInputSchema>
 ): Promise<ApiResponse<Document[]>> {
-  const { tenantId } = await withTenant()
+  const { db, tenantId } = await withTenant()
 
   const parsed = searchDocumentsInputSchema.safeParse(input)
   if (!parsed.success) {
@@ -349,7 +348,7 @@ export async function searchDocuments(
 export async function getDocument(
   input: z.infer<typeof documentIdSchema>
 ): Promise<ApiResponse<Document>> {
-  const { tenantId } = await withTenant()
+  const { db, tenantId } = await withTenant()
 
   const parsed = documentIdSchema.safeParse(input)
   if (!parsed.success) {
@@ -403,7 +402,7 @@ export async function getDocument(
 export async function getDocumentWithChunks(
   input: z.infer<typeof documentIdSchema>
 ): Promise<ApiResponse<DocumentWithChunks>> {
-  const { tenantId } = await withTenant()
+  const { db, tenantId } = await withTenant()
 
   const parsed = documentIdSchema.safeParse(input)
   if (!parsed.success) {
@@ -469,7 +468,7 @@ export async function getDocumentWithChunks(
 export async function updateDocumentTitle(
   input: z.infer<typeof updateTitleInputSchema>
 ): Promise<ApiResponse<Document>> {
-  const { tenantId } = await withTenant()
+  const { db, tenantId } = await withTenant()
 
   const parsed = updateTitleInputSchema.safeParse(input)
   if (!parsed.success) {
@@ -523,7 +522,7 @@ export async function updateDocumentTitle(
 export async function deleteDocument(
   input: z.infer<typeof documentIdSchema>
 ): Promise<ApiResponse<Document>> {
-  const { tenantId } = await withTenant()
+  const { db, tenantId } = await withTenant()
 
   const parsed = documentIdSchema.safeParse(input)
   if (!parsed.success) {
@@ -577,7 +576,7 @@ export async function deleteDocument(
 export async function restoreDocument(
   input: z.infer<typeof documentIdSchema>
 ): Promise<ApiResponse<Document>> {
-  const { tenantId } = await withTenant()
+  const { db, tenantId } = await withTenant()
 
   const parsed = documentIdSchema.safeParse(input)
   if (!parsed.success) {
@@ -639,7 +638,7 @@ export async function restoreDocument(
 export async function hardDeleteDocument(
   input: z.infer<typeof documentIdSchema>
 ): Promise<ApiResponse<{ message: string }>> {
-  const { tenantId } = await withTenant()
+  const { db, tenantId } = await withTenant()
 
   const parsed = documentIdSchema.safeParse(input)
   if (!parsed.success) {
@@ -724,7 +723,7 @@ export async function hardDeleteDocument(
 export async function retryDocumentProcessing(
   input: z.infer<typeof documentIdSchema>
 ): Promise<ApiResponse<Document>> {
-  const { tenantId } = await withTenant()
+  const { db, tenantId } = await withTenant()
 
   const parsed = documentIdSchema.safeParse(input)
   if (!parsed.success) {
@@ -803,7 +802,7 @@ export async function retryDocumentProcessing(
 export async function getDocumentDownloadUrl(
   input: z.infer<typeof documentIdSchema>
 ): Promise<ApiResponse<{ url: string; fileName: string }>> {
-  const { tenantId } = await withTenant()
+  const { db, tenantId } = await withTenant()
 
   const parsed = documentIdSchema.safeParse(input)
   if (!parsed.success) {
@@ -864,7 +863,7 @@ export async function getDocumentDownloadUrl(
  * ```
  */
 export async function getDashboardStats(): Promise<ApiResponse<DashboardStats>> {
-  const { tenantId } = await withTenant()
+  const { db, tenantId } = await withTenant()
 
   try {
     // Get all status counts in a single query using conditional aggregation


### PR DESCRIPTION
## Summary

Addresses 5 issues from the code review on PR #6:

### Security Fixes (RLS Bypass Prevention)

Files were importing `db` directly instead of using the RLS-configured instance from `withTenant()`:

| File | Fix |
|------|-----|
| `documents/actions.ts` | Use `db` from `withTenant()` for all queries |
| `generate/actions.ts` | Use `db` from `withTenant()` for tenant queries; `sharedDb` only for template queries (shared reference data) |
| `members/actions.ts` | Use `db` from `withTenant()`/`requireRole()` |
| `organization/actions.ts` | Use `db` from `withTenant()`/`requireRole()`; `sharedDb` only for `createOrganization` (no tenant context) |

### Architectural Fix

- `analyses/actions.ts`: Fixed `RiskLevel` type to use PRD-aligned taxonomy

| Before | After (PRD-aligned) |
|--------|---------------------|
| `low \| medium \| high \| critical` | `standard \| cautious \| aggressive \| unknown` |

## Test plan

- [x] Lint passes
- [ ] CI tests pass
- [ ] Manual verification of tenant isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)