### PR TITLE
Document RLS limitation and defense-in-depth tenant isolation pattern

### DIFF
--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -6,6 +6,19 @@
  * for serverless and edge runtime environments (Vercel Edge Functions,
  * Cloudflare Workers, etc.) where traditional TCP connections are not available.
  *
+ * ## IMPORTANT: RLS Context Limitation
+ *
+ * This client uses the HTTP driver (`neon-http`), where each query is an independent
+ * HTTP request. This means PostgreSQL session variables (like `app.tenant_id` for RLS)
+ * do NOT persist across queries.
+ *
+ * **Tenant isolation is enforced via application-layer filtering:**
+ * - All query functions in `src/db/queries/*.ts` include explicit `WHERE tenant_id = ?`
+ * - The `withTenant()` DAL function still calls `set_config()` for forward compatibility
+ * - If migrating to `neon-serverless` (WebSocket), RLS policies will automatically enforce
+ *
+ * See `src/lib/dal.ts` for full documentation on this known limitation.
+ *
  * @remarks
  * The Neon serverless driver uses HTTP to communicate with the database,
  * making it compatible with edge runtimes that don't support raw TCP sockets.
@@ -14,6 +27,7 @@
  *
  * @see {@link https://neon.tech/docs/serverless/serverless-driver} Neon Serverless Driver
  * @see {@link https://orm.drizzle.team/docs/get-started-postgresql#neon} Drizzle + Neon Setup
+ * @see {@link file://../lib/dal.ts} DAL with RLS limitation documentation
  *
  * @module db/client
  */

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -1,4 +1,37 @@
-// src/lib/dal.ts
+/**
+ * @fileoverview Data Access Layer (DAL) for authenticated session and tenant context.
+ *
+ * This module provides cached, request-scoped functions for:
+ * - Session verification (`verifySession`)
+ * - Tenant context with isolation (`withTenant`)
+ * - Role-based access control (`requireRole`)
+ *
+ * ## IMPORTANT: RLS Limitation with Neon HTTP Driver
+ *
+ * The current implementation uses the Neon HTTP driver (`neon-http`), which executes
+ * each query as an independent HTTP request. This means:
+ *
+ * 1. **RLS session variables do not persist across queries.** The `set_config('app.tenant_id', ...)`
+ *    call in `withTenant()` only affects the connection for that single request.
+ *    Subsequent queries may execute on different connections without the RLS context.
+ *
+ * 2. **Tenant isolation is enforced via application-layer filtering (defense-in-depth).**
+ *    All query functions in `src/db/queries/*.ts` include explicit `WHERE tenant_id = ?`
+ *    clauses, providing actual isolation regardless of RLS state.
+ *
+ * 3. **The `set_config` call is preserved for forward compatibility.** If we migrate to
+ *    the `neon-serverless` WebSocket driver (which maintains connection state), RLS
+ *    policies will automatically begin enforcing as a secondary protection layer.
+ *
+ * This is a known limitation documented in the architecture. For production-grade RLS
+ * enforcement, migrate to `neon-serverless` driver with transaction-wrapped queries.
+ *
+ * @see {@link https://neon.com/docs/serverless/serverless-driver} Neon driver options
+ * @see {@link file://../db/queries/documents.ts} Example of defense-in-depth pattern
+ *
+ * @module lib/dal
+ */
+
 import "server-only"
 
 import { cache } from "react"


### PR DESCRIPTION
## Summary
This PR documents a known architectural limitation with the current Neon HTTP driver implementation and clarifies how tenant isolation is actually enforced through application-layer filtering rather than RLS policies.

## Changes
- **CLAUDE.md**: Added "RLS Limitation (Known Issue)" section explaining that `neon-http` doesn't persist session variables across queries, and that tenant isolation relies on explicit `WHERE tenant_id = ?` clauses in all queries
- **docs/schema.md**: Updated database connection patterns table to reflect current `neon-http` usage for both databases (not `neon-serverless` as originally documented), with notes on the MVP limitation and forward compatibility plan
- **src/db/client.ts**: Added comprehensive JSDoc comments explaining the RLS context limitation and defense-in-depth pattern
- **src/lib/dal.ts**: Added detailed module-level documentation explaining the limitation, current enforcement mechanism, and migration path
- **CLAUDE.md guidelines**: Added critical note that all tenant-scoped queries MUST include explicit `WHERE tenant_id = ?` clauses

## Implementation Details
The changes clarify that:
1. **Current state (MVP)**: Uses `neon-http` driver where each query is an independent HTTP request, so PostgreSQL session variables don't persist
2. **Actual isolation**: Enforced entirely by application-layer `WHERE tenant_id = ?` filtering in all query functions
3. **Forward compatibility**: `set_config('app.tenant_id', ...)` calls are preserved so RLS policies will automatically enforce when migrating to `neon-serverless` WebSocket driver
4. **Defense-in-depth**: This pattern provides security regardless of RLS state and is acceptable for MVP

This is a documentation-only change that clarifies existing behavior and establishes clear guidelines for future development.

https://claude.ai/code/session_01AgCGX4Nd1J8JWD67Xed6RW