### PR TITLE
fix: enable independent scrolling for chat and artifact panels

### DIFF
--- a/components/shell/app-body.tsx
+++ b/components/shell/app-body.tsx
@@ -36,16 +36,17 @@ export function AppBody({ chat, artifact }: AppBodyProps) {
 
   // Desktop: side-by-side layout (like Vercel AI Chatbot)
   // Fixed chat width, artifact takes remaining space
+  // Each panel uses overflow-hidden to contain scroll within their children
   return (
     <div className="flex h-full w-full flex-1 overflow-hidden">
-      {/* Chat panel - fixed width */}
+      {/* Chat panel - fixed width, children handle scrolling */}
       <main className="flex h-full min-h-0 w-[400px] shrink-0 flex-col overflow-hidden border-r border-border/50">
         {chat}
       </main>
 
-      {/* Artifact panel - takes remaining width */}
+      {/* Artifact panel - takes remaining width, children handle scrolling */}
       <aside
-        className={cn("flex h-full flex-1 flex-col overflow-hidden")}
+        className={cn("flex h-full min-h-0 flex-1 flex-col overflow-hidden")}
         style={{
           background: "oklch(0.97 0.015 290 / 0.9)",
         }}


### PR DESCRIPTION
## Changes

- Added `min-h-0` constraint to artifact panel for proper flexbox height limiting
- Improved comments to clarify scroll behavior
- Chat panel and artifact panel now scroll independently

## Technical Details

The fix ensures both panels properly constrain their scrolling children:
- Chat panel: Conversation component (StickToBottom) has `overflow-y-auto`
- Artifact panel: ArtifactContent has `overflow-auto`
- Parent panels use `overflow-hidden` to prevent scroll propagation

Closes #38

---

Generated with [Claude Code](https://claude.ai/code)