### PR TITLE
feat: add conversation deletion with confirmation dialog

### DIFF
--- a/app/(main)/chat/actions.ts
+++ b/app/(main)/chat/actions.ts
@@ -314,10 +314,18 @@ export async function deleteConversation(
       return wrapError(new ForbiddenError("Not authorized to delete this conversation"))
     }
 
-    // Soft delete
+    const now = new Date()
+
+    // Soft delete messages first
+    await db
+      .update(messages)
+      .set({ deletedAt: now })
+      .where(eq(messages.conversationId, conversationId))
+
+    // Soft delete conversation
     await db
       .update(conversations)
-      .set({ deletedAt: new Date() })
+      .set({ deletedAt: now })
       .where(eq(conversations.id, conversationId))
 
     return ok({ deleted: true })

--- a/components/shell/app-sidebar.tsx
+++ b/components/shell/app-sidebar.tsx
@@ -13,6 +13,8 @@ import {
   ChevronDownIcon,
   BuildingIcon,
   FileText,
+  Trash2Icon,
+  MoreHorizontalIcon,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import {
@@ -64,6 +66,7 @@ interface AppSidebarProps {
   currentOrg?: Organization
   user?: User
   onSelectItem?: (item: HistoryItem) => void
+  onDeleteItem?: (item: HistoryItem) => void
   onNewChat?: () => void
   onOpenCommandPalette?: () => void
   onSwitchOrg?: (org: Organization) => void
@@ -77,6 +80,7 @@ export function AppSidebar({
   currentOrg,
   user,
   onSelectItem,
+  onDeleteItem,
   onNewChat,
   onOpenCommandPalette,
   onSwitchOrg,
@@ -185,13 +189,38 @@ export function AppSidebar({
                   const Icon = getIcon(item.type)
                   return (
                     <SidebarMenuItem key={item.id}>
-                      <SidebarMenuButton
-                        onClick={() => onSelectItem?.(item)}
-                        tooltip={item.title}
-                      >
-                        <Icon className="size-4" />
-                        <span>{item.title}</span>
-                      </SidebarMenuButton>
+                      <div className="group/item relative flex w-full items-center">
+                        <SidebarMenuButton
+                          onClick={() => onSelectItem?.(item)}
+                          tooltip={item.title}
+                          className="flex-1"
+                        >
+                          <Icon className="size-4" />
+                          <span>{item.title}</span>
+                        </SidebarMenuButton>
+                        {item.type === "conversation" && (
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <button
+                                className="absolute right-1 opacity-0 group-hover/item:opacity-100 focus:opacity-100 transition-opacity p-1 hover:bg-accent rounded-sm"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                <MoreHorizontalIcon className="size-3.5" />
+                                <span className="sr-only">More options</span>
+                              </button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end" className="w-48">
+                              <DropdownMenuItem
+                                onClick={() => onDeleteItem?.(item)}
+                                className="text-red-600 focus:text-red-600"
+                              >
+                                <Trash2Icon className="mr-2 size-4" />
+                                Delete conversation
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        )}
+                      </div>
                     </SidebarMenuItem>
                   )
                 })}

--- a/db/schema/conversations.ts
+++ b/db/schema/conversations.ts
@@ -148,6 +148,7 @@ export const messages = pgTable(
   {
     ...primaryId,
     ...timestamps,
+    ...softDelete,
 
     /**
      * Parent conversation ID.


### PR DESCRIPTION
## Summary

Implements ability to delete conversations from the chat interface with confirmation prompt to prevent accidental deletions.

## Changes

- Add soft delete support to messages table schema
- Update deleteConversation action to soft-delete associated messages
- Add context menu with delete option to conversation items in sidebar
- Add AlertDialog confirmation before deletion
- Auto-redirect to /chat if deleting currently viewed conversation
- Refresh conversation list after successful deletion

Closes #44

----

Generated with [Claude Code](https://claude.ai/code)