### PR TITLE
feat: add document attachment preview in chat input

### DIFF
--- a/app/(main)/chat/page.tsx
+++ b/app/(main)/chat/page.tsx
@@ -6,6 +6,7 @@ import { UIMessage, DefaultChatTransport } from "ai"
 import { FileTextIcon, PlusIcon, SparklesIcon, BrainIcon } from "lucide-react"
 import { useShellStore } from "@/lib/stores/shell-store"
 import { AppBody } from "@/components/shell"
+import { toast } from "sonner"
 import {
   Conversation,
   ConversationContent,
@@ -18,6 +19,7 @@ import {
   Suggestion,
   PromptInput,
   PromptInputProvider,
+  PromptInputHeader,
   PromptInputTextarea,
   PromptInputFooter,
   PromptInputTools,
@@ -28,6 +30,7 @@ import {
   PromptInputActionMenuItem,
   PromptInputActionAddAttachments,
   InputAutocomplete,
+  AttachmentPreview,
   type SlashCommand,
   type Mention,
   type PromptInputMessage,
@@ -527,9 +530,28 @@ export default function ChatPage() {
               <PromptInputProvider initialInput={inputValue}>
                 <PromptInput
                   onSubmit={handleSubmit}
-                  accept="application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.pdf,.docx"
+                  accept="application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,text/plain,.pdf,.docx,.txt"
                   multiple
+                  maxFileSize={50 * 1024 * 1024} // 50MB max file size
+                  onError={(err) => {
+                    if (err.code === "max_file_size") {
+                      toast.error("File too large", {
+                        description: "Maximum file size is 50MB. Please choose a smaller file.",
+                      })
+                    } else if (err.code === "accept") {
+                      toast.error("Unsupported file type", {
+                        description: "Please upload PDF, DOCX, or TXT files only.",
+                      })
+                    } else if (err.code === "max_files") {
+                      toast.warning("Too many files", {
+                        description: err.message,
+                      })
+                    }
+                  }}
                 >
+                  <PromptInputHeader>
+                    <AttachmentPreview />
+                  </PromptInputHeader>
                   <PromptInputTextarea
                     placeholder="Ask about NDAs or upload a document... (try /help)"
                     value={inputValue}

--- a/components/chat/attachment-preview.tsx
+++ b/components/chat/attachment-preview.tsx
@@ -1,0 +1,123 @@
+"use client"
+
+import * as React from "react"
+import { FileTextIcon, FileIcon, XIcon } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { usePromptInputAttachments } from "@/components/ai-elements/prompt-input"
+import type { FileUIPart } from "ai"
+
+/**
+ * Displays a preview of attached files with remove buttons.
+ * Integrates with PromptInput's attachment context.
+ */
+export function AttachmentPreview({
+  className,
+}: {
+  className?: string
+}) {
+  const { files, remove } = usePromptInputAttachments()
+
+  if (files.length === 0) {
+    return null
+  }
+
+  return (
+    <div className={cn("flex flex-wrap gap-2", className)}>
+      {files.map((file) => (
+        <AttachmentChip
+          key={file.id}
+          file={file}
+          onRemove={() => remove(file.id)}
+        />
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Individual attachment chip with file info and remove button.
+ */
+function AttachmentChip({
+  file,
+  onRemove,
+}: {
+  file: FileUIPart & { id: string }
+  onRemove: () => void
+}) {
+  const icon = getFileIcon(file.mediaType, file.filename)
+  const displayName = truncateFilename(file.filename || "Attachment")
+  const fileSize = file.url?.startsWith("blob:") ? null : null // Size not available from blob URL
+
+  return (
+    <div className="group relative flex items-center gap-2 rounded-md border bg-muted/50 px-3 py-2 transition-colors hover:bg-muted">
+      <div className="shrink-0">{icon}</div>
+      <div className="flex min-w-0 flex-col">
+        <span className="truncate text-sm font-medium">{displayName}</span>
+        {fileSize && (
+          <span className="text-muted-foreground text-xs">{fileSize}</span>
+        )}
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        className="ml-2 shrink-0 opacity-60 transition-opacity hover:opacity-100"
+        onClick={onRemove}
+        aria-label={`Remove ${displayName}`}
+      >
+        <XIcon className="size-3.5" />
+      </Button>
+    </div>
+  )
+}
+
+/**
+ * Returns appropriate icon for file type.
+ */
+function getFileIcon(mediaType?: string, filename?: string) {
+  // Check media type first
+  if (mediaType?.startsWith("application/pdf") || filename?.endsWith(".pdf")) {
+    return <FileTextIcon className="size-4 text-red-500" />
+  }
+
+  if (
+    mediaType?.includes("wordprocessingml") ||
+    mediaType?.includes("msword") ||
+    filename?.endsWith(".docx") ||
+    filename?.endsWith(".doc")
+  ) {
+    return <FileTextIcon className="size-4 text-blue-500" />
+  }
+
+  if (mediaType?.startsWith("text/") || filename?.endsWith(".txt")) {
+    return <FileTextIcon className="size-4 text-gray-500" />
+  }
+
+  // Default file icon
+  return <FileIcon className="size-4 text-muted-foreground" />
+}
+
+/**
+ * Truncates long filenames while preserving extension.
+ */
+function truncateFilename(filename: string, maxLength: number = 30): string {
+  if (filename.length <= maxLength) {
+    return filename
+  }
+
+  const lastDotIndex = filename.lastIndexOf(".")
+  if (lastDotIndex === -1) {
+    return filename.slice(0, maxLength - 3) + "..."
+  }
+
+  const extension = filename.slice(lastDotIndex)
+  const name = filename.slice(0, lastDotIndex)
+  const availableLength = maxLength - extension.length - 3 // 3 for "..."
+
+  if (availableLength <= 0) {
+    return "..." + extension
+  }
+
+  return name.slice(0, availableLength) + "..." + extension
+}

--- a/components/chat/index.ts
+++ b/components/chat/index.ts
@@ -69,3 +69,6 @@ export {
   type SlashCommand,
   type Mention,
 } from "./slash-commands"
+
+// Attachment preview
+export { AttachmentPreview } from "./attachment-preview"


### PR DESCRIPTION
## Summary

Adds visual preview of attached files in chat input before sending messages.

## Changes

- Created `AttachmentPreview` component with file chips showing type icons, names, and remove buttons
- Integrated preview into chat input using `PromptInputHeader`
- Added error handling with Sonner toasts for file validation
- Supports PDF, DOCX, and TXT files with 50MB max size
- Leverages existing AI Elements attachment infrastructure

Closes #45

🤖 Generated with [Claude Code](https://claude.ai/code)