### PR TITLE
feat: organization management and switching

### DIFF
--- a/app/(main)/settings/organization/members/members-management.tsx
+++ b/app/(main)/settings/organization/members/members-management.tsx
@@ -1,0 +1,523 @@
+"use client"
+
+/**
+ * @fileoverview Members management component
+ */
+
+import { useState, useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { MoreHorizontal, Mail, UserPlus, Crown, Shield, User, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import {
+  getOrganizationMembers,
+  getOrganizationInvitations,
+  inviteMember,
+  updateMemberRole,
+  removeMember,
+  cancelInvitation,
+} from "@/app/actions/organizations"
+
+interface Member {
+  id: string
+  userId: string
+  name: string | null
+  email: string
+  image: string | null
+  role: string
+  acceptedAt: Date | null
+}
+
+interface Invitation {
+  id: string
+  email: string
+  role: string
+  status: string
+  expiresAt: Date
+  inviterName: string | null
+  createdAt: Date
+}
+
+interface MembersManagementProps {
+  canManage: boolean
+  currentUserRole: string
+  currentUserId: string
+}
+
+const roleIcons = {
+  owner: Crown,
+  admin: Shield,
+  member: User,
+}
+
+export function MembersManagement({
+  canManage,
+  currentUserRole,
+  currentUserId,
+}: MembersManagementProps) {
+  const router = useRouter()
+  const [members, setMembers] = useState<Member[]>([])
+  const [invitations, setInvitations] = useState<Invitation[]>([])
+  const [loading, setLoading] = useState(true)
+  const [inviteOpen, setInviteOpen] = useState(false)
+  const [inviteEmail, setInviteEmail] = useState("")
+  const [inviteRole, setInviteRole] = useState<"member" | "admin" | "owner">("member")
+  const [inviting, setInviting] = useState(false)
+  const [memberToRemove, setMemberToRemove] = useState<Member | null>(null)
+  const [removing, setRemoving] = useState(false)
+  const [invitationToCancel, setInvitationToCancel] = useState<Invitation | null>(null)
+  const [canceling, setCanceling] = useState(false)
+
+  useEffect(() => {
+    loadData()
+  }, [])
+
+  async function loadData() {
+    setLoading(true)
+    const [membersResult, invitationsResult] = await Promise.all([
+      getOrganizationMembers(),
+      canManage ? getOrganizationInvitations() : Promise.resolve({ success: true, data: [] }),
+    ])
+
+    if (membersResult.success) {
+      setMembers(membersResult.data)
+    }
+    if (invitationsResult.success) {
+      setInvitations(invitationsResult.data)
+    }
+    setLoading(false)
+  }
+
+  async function handleInvite() {
+    setInviting(true)
+    const result = await inviteMember({ email: inviteEmail, role: inviteRole })
+
+    if (result.success) {
+      toast.success("Invitation sent")
+      setInviteEmail("")
+      setInviteRole("member")
+      setInviteOpen(false)
+      loadData()
+    } else {
+      toast.error(result.error.message)
+    }
+    setInviting(false)
+  }
+
+  async function handleUpdateRole(memberId: string, newRole: string) {
+    const result = await updateMemberRole({ memberId, role: newRole as "owner" | "admin" | "member" })
+
+    if (result.success) {
+      toast.success("Role updated")
+      loadData()
+    } else {
+      toast.error(result.error.message)
+    }
+  }
+
+  async function handleRemove() {
+    if (!memberToRemove) return
+
+    setRemoving(true)
+    const result = await removeMember(memberToRemove.id)
+
+    if (result.success) {
+      toast.success("Member removed")
+      setMemberToRemove(null)
+      loadData()
+    } else {
+      toast.error(result.error.message)
+    }
+    setRemoving(false)
+  }
+
+  async function handleCancelInvitation() {
+    if (!invitationToCancel) return
+
+    setCanceling(true)
+    const result = await cancelInvitation(invitationToCancel.id)
+
+    if (result.success) {
+      toast.success("Invitation cancelled")
+      setInvitationToCancel(null)
+      loadData()
+    } else {
+      toast.error(result.error.message)
+    }
+    setCanceling(false)
+  }
+
+  function getRoleIcon(role: string) {
+    const Icon = roleIcons[role as keyof typeof roleIcons] || User
+    return <Icon className="h-4 w-4" />
+  }
+
+  function getInitials(name: string | null, email: string): string {
+    if (name) {
+      return name
+        .split(" ")
+        .map((n) => n[0])
+        .join("")
+        .toUpperCase()
+        .slice(0, 2)
+    }
+    return email[0].toUpperCase()
+  }
+
+  const canModifyMember = (member: Member) => {
+    if (!canManage) return false
+    if (member.userId === currentUserId) return false // Can't modify yourself
+    if (currentUserRole === "admin" && member.role === "owner") return false
+    return true
+  }
+
+  return (
+    <Tabs defaultValue="members" className="space-y-4">
+      <TabsList>
+        <TabsTrigger value="members">Members</TabsTrigger>
+        {canManage && <TabsTrigger value="invitations">Invitations</TabsTrigger>}
+      </TabsList>
+
+      <TabsContent value="members" className="space-y-4">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0">
+            <div>
+              <CardTitle>Organization Members</CardTitle>
+              <CardDescription>
+                {members.length} member{members.length !== 1 ? "s" : ""}
+              </CardDescription>
+            </div>
+            {canManage && (
+              <Dialog open={inviteOpen} onOpenChange={setInviteOpen}>
+                <DialogTrigger asChild>
+                  <Button>
+                    <UserPlus className="mr-2 h-4 w-4" />
+                    Invite Member
+                  </Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Invite Member</DialogTitle>
+                    <DialogDescription>
+                      Send an invitation to join your organization
+                    </DialogDescription>
+                  </DialogHeader>
+                  <div className="space-y-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="email">Email</Label>
+                      <Input
+                        id="email"
+                        type="email"
+                        placeholder="user@example.com"
+                        value={inviteEmail}
+                        onChange={(e) => setInviteEmail(e.target.value)}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="role">Role</Label>
+                      <Select
+                        value={inviteRole}
+                        onValueChange={(value) =>
+                          setInviteRole(value as "member" | "admin" | "owner")
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="member">Member</SelectItem>
+                          <SelectItem value="admin">Admin</SelectItem>
+                          {currentUserRole === "owner" && (
+                            <SelectItem value="owner">Owner</SelectItem>
+                          )}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+                  <DialogFooter>
+                    <Button
+                      onClick={handleInvite}
+                      disabled={!inviteEmail || inviting}
+                    >
+                      {inviting ? "Sending..." : "Send Invitation"}
+                    </Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
+            )}
+          </CardHeader>
+          <CardContent>
+            {loading ? (
+              <div className="text-center py-8 text-muted-foreground">
+                Loading members...
+              </div>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Member</TableHead>
+                    <TableHead>Email</TableHead>
+                    <TableHead>Role</TableHead>
+                    {canManage && <TableHead className="w-[50px]"></TableHead>}
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {members.map((member) => (
+                    <TableRow key={member.id}>
+                      <TableCell>
+                        <div className="flex items-center gap-3">
+                          <Avatar className="h-8 w-8">
+                            <AvatarImage src={member.image || undefined} />
+                            <AvatarFallback>
+                              {getInitials(member.name, member.email)}
+                            </AvatarFallback>
+                          </Avatar>
+                          <div className="flex flex-col">
+                            <span className="font-medium">
+                              {member.name || "Unknown"}
+                            </span>
+                            {member.userId === currentUserId && (
+                              <span className="text-xs text-muted-foreground">You</span>
+                            )}
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">
+                        {member.email}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          {getRoleIcon(member.role)}
+                          <span className="capitalize">{member.role}</span>
+                        </div>
+                      </TableCell>
+                      {canManage && (
+                        <TableCell>
+                          {canModifyMember(member) && (
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <Button variant="ghost" size="sm">
+                                  <MoreHorizontal className="h-4 w-4" />
+                                </Button>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent align="end">
+                                <DropdownMenuLabel>Change Role</DropdownMenuLabel>
+                                <DropdownMenuItem
+                                  onClick={() => handleUpdateRole(member.id, "member")}
+                                  disabled={member.role === "member"}
+                                >
+                                  <User className="mr-2 h-4 w-4" />
+                                  Member
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                  onClick={() => handleUpdateRole(member.id, "admin")}
+                                  disabled={member.role === "admin"}
+                                >
+                                  <Shield className="mr-2 h-4 w-4" />
+                                  Admin
+                                </DropdownMenuItem>
+                                {currentUserRole === "owner" && (
+                                  <DropdownMenuItem
+                                    onClick={() => handleUpdateRole(member.id, "owner")}
+                                    disabled={member.role === "owner"}
+                                  >
+                                    <Crown className="mr-2 h-4 w-4" />
+                                    Owner
+                                  </DropdownMenuItem>
+                                )}
+                                <DropdownMenuSeparator />
+                                <DropdownMenuItem
+                                  onClick={() => setMemberToRemove(member)}
+                                  className="text-destructive focus:text-destructive"
+                                >
+                                  Remove Member
+                                </DropdownMenuItem>
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          )}
+                        </TableCell>
+                      )}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+      </TabsContent>
+
+      {canManage && (
+        <TabsContent value="invitations" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Pending Invitations</CardTitle>
+              <CardDescription>
+                {invitations.length} pending invitation
+                {invitations.length !== 1 ? "s" : ""}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {loading ? (
+                <div className="text-center py-8 text-muted-foreground">
+                  Loading invitations...
+                </div>
+              ) : invitations.length === 0 ? (
+                <div className="text-center py-8 text-muted-foreground">
+                  No pending invitations
+                </div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Email</TableHead>
+                      <TableHead>Role</TableHead>
+                      <TableHead>Invited By</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Expires</TableHead>
+                      <TableHead className="w-[50px]"></TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {invitations.map((invitation) => (
+                      <TableRow key={invitation.id}>
+                        <TableCell className="font-medium">
+                          {invitation.email}
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center gap-2">
+                            {getRoleIcon(invitation.role)}
+                            <span className="capitalize">{invitation.role}</span>
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-muted-foreground">
+                          {invitation.inviterName || "Unknown"}
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="outline" className="capitalize">
+                            {invitation.status}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-muted-foreground text-sm">
+                          {new Date(invitation.expiresAt).toLocaleDateString()}
+                        </TableCell>
+                        <TableCell>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setInvitationToCancel(invitation)}
+                          >
+                            <X className="h-4 w-4" />
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+      )}
+
+      {/* Remove Member Confirmation Dialog */}
+      <AlertDialog
+        open={!!memberToRemove}
+        onOpenChange={(open) => !open && setMemberToRemove(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove Member</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to remove {memberToRemove?.name || memberToRemove?.email} from
+              the organization? They will lose access to all organization resources.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleRemove}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {removing ? "Removing..." : "Remove Member"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Cancel Invitation Confirmation Dialog */}
+      <AlertDialog
+        open={!!invitationToCancel}
+        onOpenChange={(open) => !open && setInvitationToCancel(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Cancel Invitation</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to cancel the invitation to {invitationToCancel?.email}?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleCancelInvitation}>
+              {canceling ? "Cancelling..." : "Cancel Invitation"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Tabs>
+  )
+}

--- a/app/(main)/settings/organization/members/members-management.tsx
+++ b/app/(main)/settings/organization/members/members-management.tsx
@@ -4,10 +4,9 @@
  * @fileoverview Members management component
  */
 
-import { useState, useEffect } from "react"
-import { useRouter } from "next/navigation"
+import { useState, useEffect, useCallback } from "react"
 import { toast } from "sonner"
-import { MoreHorizontal, Mail, UserPlus, Crown, Shield, User, X } from "lucide-react"
+import { MoreHorizontal, UserPlus, Crown, Shield, User, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -109,7 +108,6 @@ export function MembersManagement({
   currentUserRole,
   currentUserId,
 }: MembersManagementProps) {
-  const router = useRouter()
   const [members, setMembers] = useState<Member[]>([])
   const [invitations, setInvitations] = useState<Invitation[]>([])
   const [loading, setLoading] = useState(true)
@@ -122,11 +120,7 @@ export function MembersManagement({
   const [invitationToCancel, setInvitationToCancel] = useState<Invitation | null>(null)
   const [canceling, setCanceling] = useState(false)
 
-  useEffect(() => {
-    loadData()
-  }, [])
-
-  async function loadData() {
+  const loadData = useCallback(async () => {
     setLoading(true)
     const [membersResult, invitationsResult] = await Promise.all([
       getOrganizationMembers(),
@@ -140,7 +134,12 @@ export function MembersManagement({
       setInvitations(invitationsResult.data)
     }
     setLoading(false)
-  }
+  }, [canManage])
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Data fetching on mount is a valid pattern
+    loadData()
+  }, [loadData])
 
   async function handleInvite() {
     setInviting(true)

--- a/app/(main)/settings/organization/members/page.tsx
+++ b/app/(main)/settings/organization/members/page.tsx
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview Organization members management page
+ */
+
+import { withTenant } from "@/lib/dal"
+import { MembersManagement } from "./members-management"
+
+export default async function OrganizationMembersPage() {
+  const ctx = await withTenant()
+
+  const canManage = ["owner", "admin"].includes(ctx.role)
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Members</h1>
+        <p className="text-muted-foreground">
+          Manage organization members and invitations
+        </p>
+      </div>
+
+      <MembersManagement
+        canManage={canManage}
+        currentUserRole={ctx.role}
+        currentUserId={ctx.userId as string}
+      />
+    </div>
+  )
+}

--- a/app/(main)/settings/organization/organization-settings-form.tsx
+++ b/app/(main)/settings/organization/organization-settings-form.tsx
@@ -1,0 +1,182 @@
+"use client"
+
+/**
+ * @fileoverview Organization settings form component
+ */
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { updateOrganization, deleteOrganization } from "@/app/actions/organizations"
+
+interface Organization {
+  id: string
+  name: string
+  slug: string
+  plan: string
+  createdAt: Date
+}
+
+interface OrganizationSettingsFormProps {
+  organization: Organization
+  canManage: boolean
+  isOwner: boolean
+}
+
+export function OrganizationSettingsForm({
+  organization,
+  canManage,
+  isOwner,
+}: OrganizationSettingsFormProps) {
+  const router = useRouter()
+  const [name, setName] = useState(organization.name)
+  const [slug, setSlug] = useState(organization.slug)
+  const [saving, setSaving] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+
+  async function handleSave() {
+    setSaving(true)
+    const result = await updateOrganization({ name, slug })
+
+    if (result.success) {
+      toast.success("Organization updated")
+      router.refresh()
+    } else {
+      toast.error(result.error.message)
+    }
+    setSaving(false)
+  }
+
+  async function handleDelete() {
+    setDeleting(true)
+    const result = await deleteOrganization()
+
+    if (!result.success) {
+      toast.error(result.error.message)
+      setDeleting(false)
+    }
+    // On success, user is redirected to onboarding
+  }
+
+  const hasChanges = name !== organization.name || slug !== organization.slug
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>General Information</CardTitle>
+          <CardDescription>
+            Update your organization name and URL slug
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="name">Organization Name</Label>
+            <Input
+              id="name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              disabled={!canManage}
+              placeholder="Acme Corporation"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="slug">URL Slug</Label>
+            <Input
+              id="slug"
+              value={slug}
+              onChange={(e) => setSlug(e.target.value.toLowerCase())}
+              disabled={!canManage}
+              placeholder="acme-corp"
+              pattern="[a-z0-9-]+"
+            />
+            <p className="text-sm text-muted-foreground">
+              Lowercase letters, numbers, and hyphens only
+            </p>
+          </div>
+          <div className="space-y-2">
+            <Label>Plan</Label>
+            <div className="text-sm font-medium capitalize">{organization.plan}</div>
+          </div>
+          <div className="space-y-2">
+            <Label>Created</Label>
+            <div className="text-sm text-muted-foreground">
+              {new Date(organization.createdAt).toLocaleDateString()}
+            </div>
+          </div>
+        </CardContent>
+        {canManage && (
+          <CardFooter>
+            <Button
+              onClick={handleSave}
+              disabled={!hasChanges || saving}
+            >
+              {saving ? "Saving..." : "Save Changes"}
+            </Button>
+          </CardFooter>
+        )}
+      </Card>
+
+      {isOwner && (
+        <Card className="border-destructive">
+          <CardHeader>
+            <CardTitle className="text-destructive">Danger Zone</CardTitle>
+            <CardDescription>
+              Permanently delete this organization and all associated data
+            </CardDescription>
+          </CardHeader>
+          <CardFooter>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="destructive" disabled={deleting}>
+                  Delete Organization
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This action cannot be undone. This will permanently delete the
+                    organization &quot;{organization.name}&quot; and remove all
+                    associated documents, analyses, and data.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={handleDelete}
+                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  >
+                    {deleting ? "Deleting..." : "Delete Organization"}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </CardFooter>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/app/(main)/settings/organization/page.tsx
+++ b/app/(main)/settings/organization/page.tsx
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview Organization settings page
+ *
+ * Displays organization details and allows owners/admins to update settings.
+ */
+
+import { withTenant } from "@/lib/dal"
+import { db } from "@/db"
+import { organizations } from "@/db/schema"
+import { eq } from "drizzle-orm"
+import { OrganizationSettingsForm } from "./organization-settings-form"
+import { NotFoundError } from "@/lib/errors"
+
+export default async function OrganizationSettingsPage() {
+  const ctx = await withTenant()
+
+  const organization = await db.query.organizations.findFirst({
+    where: eq(organizations.id, ctx.tenantId as string),
+  })
+
+  if (!organization) {
+    throw new NotFoundError("Organization not found")
+  }
+
+  const canManage = ["owner", "admin"].includes(ctx.role)
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Organization Settings</h1>
+        <p className="text-muted-foreground">
+          Manage your organization details and settings
+        </p>
+      </div>
+
+      <OrganizationSettingsForm
+        organization={organization}
+        canManage={canManage}
+        isOwner={ctx.role === "owner"}
+      />
+    </div>
+  )
+}

--- a/app/(main)/settings/organizations/new/create-organization-form.tsx
+++ b/app/(main)/settings/organizations/new/create-organization-form.tsx
@@ -1,0 +1,127 @@
+"use client"
+
+/**
+ * @fileoverview Create organization form component
+ */
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { createOrganization, switchOrganization } from "@/app/actions/organizations"
+
+export function CreateOrganizationForm() {
+  const router = useRouter()
+  const [name, setName] = useState("")
+  const [slug, setSlug] = useState("")
+  const [creating, setCreating] = useState(false)
+
+  // Auto-generate slug from name
+  function handleNameChange(value: string) {
+    setName(value)
+    if (!slug || slug === generateSlug(name)) {
+      setSlug(generateSlug(value))
+    }
+  }
+
+  function generateSlug(text: string): string {
+    return text
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, "")
+      .replace(/\s+/g, "-")
+      .replace(/-+/g, "-")
+      .slice(0, 50)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+
+    if (!name || !slug) {
+      toast.error("Please fill in all fields")
+      return
+    }
+
+    setCreating(true)
+    const result = await createOrganization({ name, slug })
+
+    if (result.success) {
+      toast.success("Organization created")
+
+      // Switch to the new organization
+      const switchResult = await switchOrganization(result.data.id)
+      if (switchResult.success) {
+        router.push("/dashboard")
+        router.refresh()
+      } else {
+        router.push("/settings/organizations")
+      }
+    } else {
+      toast.error(result.error.message)
+      setCreating(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Card>
+        <CardHeader>
+          <CardTitle>Organization Details</CardTitle>
+          <CardDescription>
+            Choose a name and URL for your new organization
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="name">Organization Name</Label>
+            <Input
+              id="name"
+              value={name}
+              onChange={(e) => handleNameChange(e.target.value)}
+              placeholder="Acme Corporation"
+              required
+              maxLength={100}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="slug">URL Slug</Label>
+            <Input
+              id="slug"
+              value={slug}
+              onChange={(e) => setSlug(generateSlug(e.target.value))}
+              placeholder="acme-corp"
+              pattern="[a-z0-9-]+"
+              required
+              maxLength={50}
+            />
+            <p className="text-sm text-muted-foreground">
+              Lowercase letters, numbers, and hyphens only. This will be used in URLs.
+            </p>
+          </div>
+        </CardContent>
+        <CardFooter className="flex gap-3">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => router.back()}
+            disabled={creating}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={creating || !name || !slug}>
+            {creating ? "Creating..." : "Create Organization"}
+          </Button>
+        </CardFooter>
+      </Card>
+    </form>
+  )
+}

--- a/app/(main)/settings/organizations/new/page.tsx
+++ b/app/(main)/settings/organizations/new/page.tsx
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview Create new organization page
+ */
+
+import { verifySession } from "@/lib/dal"
+import { CreateOrganizationForm } from "./create-organization-form"
+
+export default async function NewOrganizationPage() {
+  await verifySession() // Ensure user is authenticated
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Create Organization</h1>
+        <p className="text-muted-foreground">
+          Create a new organization to collaborate with your team
+        </p>
+      </div>
+
+      <CreateOrganizationForm />
+    </div>
+  )
+}

--- a/app/(main)/settings/organizations/organizations-list.tsx
+++ b/app/(main)/settings/organizations/organizations-list.tsx
@@ -4,7 +4,7 @@
  * @fileoverview Organizations list component
  */
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import { Building2, Mail, Check, X } from "lucide-react"
@@ -49,11 +49,7 @@ export function OrganizationsList() {
   const [loading, setLoading] = useState(true)
   const [processing, setProcessing] = useState<string | null>(null)
 
-  useEffect(() => {
-    loadData()
-  }, [])
-
-  async function loadData() {
+  const loadData = useCallback(async () => {
     setLoading(true)
     const [orgsResult, invitesResult] = await Promise.all([
       getUserOrganizations(),
@@ -67,7 +63,12 @@ export function OrganizationsList() {
       setInvitations(invitesResult.data)
     }
     setLoading(false)
-  }
+  }, [])
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Data fetching on mount is a valid pattern
+    loadData()
+  }, [loadData])
 
   async function handleAccept(token: string) {
     setProcessing(token)

--- a/app/(main)/settings/organizations/organizations-list.tsx
+++ b/app/(main)/settings/organizations/organizations-list.tsx
@@ -1,0 +1,211 @@
+"use client"
+
+/**
+ * @fileoverview Organizations list component
+ */
+
+import { useState, useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { Building2, Mail, Check, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import {
+  getUserOrganizations,
+  getUserInvitations,
+  acceptInvitation,
+  declineInvitation,
+} from "@/app/actions/organizations"
+
+interface Organization {
+  id: string
+  name: string
+  slug: string
+  role: string
+  memberCount: number
+}
+
+interface Invitation {
+  id: string
+  token: string
+  organizationName: string
+  organizationSlug: string
+  role: string
+  expiresAt: Date
+  inviterName: string | null
+}
+
+export function OrganizationsList() {
+  const router = useRouter()
+  const [organizations, setOrganizations] = useState<Organization[]>([])
+  const [invitations, setInvitations] = useState<Invitation[]>([])
+  const [loading, setLoading] = useState(true)
+  const [processing, setProcessing] = useState<string | null>(null)
+
+  useEffect(() => {
+    loadData()
+  }, [])
+
+  async function loadData() {
+    setLoading(true)
+    const [orgsResult, invitesResult] = await Promise.all([
+      getUserOrganizations(),
+      getUserInvitations(),
+    ])
+
+    if (orgsResult.success) {
+      setOrganizations(orgsResult.data)
+    }
+    if (invitesResult.success) {
+      setInvitations(invitesResult.data)
+    }
+    setLoading(false)
+  }
+
+  async function handleAccept(token: string) {
+    setProcessing(token)
+    const result = await acceptInvitation(token)
+
+    if (result.success) {
+      toast.success("Invitation accepted")
+      loadData()
+      router.refresh()
+    } else {
+      toast.error(result.error.message)
+    }
+    setProcessing(null)
+  }
+
+  async function handleDecline(token: string) {
+    setProcessing(token)
+    const result = await declineInvitation(token)
+
+    if (result.success) {
+      toast.success("Invitation declined")
+      loadData()
+    } else {
+      toast.error(result.error.message)
+    }
+    setProcessing(null)
+  }
+
+  return (
+    <div className="space-y-6">
+      {invitations.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Pending Invitations</CardTitle>
+            <CardDescription>
+              You have {invitations.length} pending invitation
+              {invitations.length !== 1 ? "s" : ""}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {invitations.map((invitation) => (
+              <div
+                key={invitation.id}
+                className="flex items-center justify-between p-4 border rounded-lg"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="h-10 w-10 rounded-full bg-muted flex items-center justify-center">
+                    <Mail className="h-5 w-5" />
+                  </div>
+                  <div>
+                    <p className="font-medium">{invitation.organizationName}</p>
+                    <p className="text-sm text-muted-foreground">
+                      Invited as{" "}
+                      <span className="capitalize">{invitation.role}</span>
+                      {invitation.inviterName && ` by ${invitation.inviterName}`}
+                    </p>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Expires {new Date(invitation.expiresAt).toLocaleDateString()}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  <Button
+                    size="sm"
+                    onClick={() => handleAccept(invitation.token)}
+                    disabled={processing === invitation.token}
+                  >
+                    <Check className="mr-2 h-4 w-4" />
+                    Accept
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => handleDecline(invitation.token)}
+                    disabled={processing === invitation.token}
+                  >
+                    <X className="mr-2 h-4 w-4" />
+                    Decline
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <div>
+            <CardTitle>Your Organizations</CardTitle>
+            <CardDescription>
+              {organizations.length} organization
+              {organizations.length !== 1 ? "s" : ""}
+            </CardDescription>
+          </div>
+          <Button onClick={() => router.push("/settings/organizations/new")}>
+            <Building2 className="mr-2 h-4 w-4" />
+            Create Organization
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="text-center py-8 text-muted-foreground">
+              Loading organizations...
+            </div>
+          ) : organizations.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              No organizations yet
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {organizations.map((org) => (
+                <div
+                  key={org.id}
+                  className="flex items-center justify-between p-4 border rounded-lg hover:bg-accent cursor-pointer"
+                  onClick={() => router.push("/settings/organization")}
+                >
+                  <div className="flex items-center gap-4">
+                    <div className="h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center">
+                      <Building2 className="h-5 w-5 text-primary" />
+                    </div>
+                    <div>
+                      <p className="font-medium">{org.name}</p>
+                      <p className="text-sm text-muted-foreground">
+                        {org.memberCount} member{org.memberCount !== 1 ? "s" : ""} ·{" "}
+                        <span className="capitalize">{org.role}</span>
+                      </p>
+                    </div>
+                  </div>
+                  <Badge variant="outline" className="capitalize">
+                    {org.role}
+                  </Badge>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/(main)/settings/organizations/page.tsx
+++ b/app/(main)/settings/organizations/page.tsx
@@ -1,0 +1,25 @@
+/**
+ * @fileoverview User's organizations page
+ *
+ * Shows all organizations the user belongs to and pending invitations.
+ */
+
+import { verifySession } from "@/lib/dal"
+import { OrganizationsList } from "./organizations-list"
+
+export default async function OrganizationsPage() {
+  await verifySession() // Ensure user is authenticated
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Your Organizations</h1>
+        <p className="text-muted-foreground">
+          Manage your organization memberships and invitations
+        </p>
+      </div>
+
+      <OrganizationsList />
+    </div>
+  )
+}

--- a/app/actions/organizations.test.ts
+++ b/app/actions/organizations.test.ts
@@ -1,0 +1,699 @@
+/**
+ * @fileoverview Tests for organization management server actions
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { testDb } from "@/test/setup"
+import {
+  users,
+  organizations,
+  organizationMembers,
+  organizationInvitations,
+  sessions,
+} from "@/db/schema"
+import {
+  createOrganization,
+  updateOrganization,
+  getUserOrganizations,
+  switchOrganization,
+  getOrganizationMembers,
+  updateMemberRole,
+  removeMember,
+  inviteMember,
+  acceptInvitation,
+  declineInvitation,
+} from "./organizations"
+import * as dal from "@/lib/dal"
+import * as auth from "@/lib/auth"
+
+// Mock dependencies
+vi.mock("@/lib/dal")
+vi.mock("@/lib/auth")
+vi.mock("next/navigation", () => ({
+  revalidatePath: vi.fn(),
+  redirect: vi.fn(),
+}))
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}))
+
+describe("Organization CRUD", () => {
+  let testUser: typeof users.$inferSelect
+  let testOrg: typeof organizations.$inferSelect
+
+  beforeEach(async () => {
+    // Create test user
+    ;[testUser] = await testDb
+      .insert(users)
+      .values({
+        email: "test@example.com",
+        name: "Test User",
+      })
+      .returning()
+
+    // Create test organization
+    ;[testOrg] = await testDb
+      .insert(organizations)
+      .values({
+        name: "Test Org",
+        slug: "test-org",
+      })
+      .returning()
+
+    // Add user as owner
+    await testDb.insert(organizationMembers).values({
+      organizationId: testOrg.id,
+      userId: testUser.id,
+      role: "owner",
+      acceptedAt: new Date(),
+    })
+
+    // Mock verifySession to return test user
+    vi.mocked(dal.verifySession).mockResolvedValue({
+      userId: testUser.id as any,
+      user: {
+        id: testUser.id,
+        email: testUser.email,
+        name: testUser.name,
+      },
+      activeOrganizationId: testOrg.id as any,
+    })
+  })
+
+  describe("createOrganization", () => {
+    it("should create a new organization and add user as owner", async () => {
+      const result = await createOrganization({
+        name: "New Org",
+        slug: "new-org",
+      })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        const org = await testDb.query.organizations.findFirst({
+          where: (t, { eq }) => eq(t.id, result.data.id),
+        })
+        expect(org?.name).toBe("New Org")
+        expect(org?.slug).toBe("new-org")
+
+        const membership = await testDb.query.organizationMembers.findFirst({
+          where: (t, { eq, and }) =>
+            and(eq(t.organizationId, result.data.id), eq(t.userId, testUser.id)),
+        })
+        expect(membership?.role).toBe("owner")
+        expect(membership?.acceptedAt).toBeTruthy()
+      }
+    })
+
+    it("should reject duplicate slugs", async () => {
+      const result = await createOrganization({
+        name: "Another Org",
+        slug: "test-org", // Already exists
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe("CONFLICT")
+      }
+    })
+
+    it("should validate slug format", async () => {
+      const result = await createOrganization({
+        name: "Invalid Org",
+        slug: "Invalid Slug!", // Contains invalid characters
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe("VALIDATION_ERROR")
+      }
+    })
+  })
+
+  describe("updateOrganization", () => {
+    beforeEach(() => {
+      // Mock requireRole to return tenant context
+      vi.mocked(dal.requireRole).mockResolvedValue({
+        userId: testUser.id as any,
+        user: {
+          id: testUser.id,
+          email: testUser.email,
+          name: testUser.name,
+        },
+        activeOrganizationId: testOrg.id as any,
+        tenantId: testOrg.id as any,
+        role: "owner",
+        db: testDb,
+      } as any)
+    })
+
+    it("should update organization name", async () => {
+      const result = await updateOrganization({
+        name: "Updated Name",
+      })
+
+      expect(result.success).toBe(true)
+
+      const org = await testDb.query.organizations.findFirst({
+        where: (t, { eq }) => eq(t.id, testOrg.id),
+      })
+      expect(org?.name).toBe("Updated Name")
+    })
+
+    it("should update organization slug", async () => {
+      const result = await updateOrganization({
+        slug: "updated-slug",
+      })
+
+      expect(result.success).toBe(true)
+
+      const org = await testDb.query.organizations.findFirst({
+        where: (t, { eq }) => eq(t.id, testOrg.id),
+      })
+      expect(org?.slug).toBe("updated-slug")
+    })
+
+    it("should reject duplicate slugs", async () => {
+      // Create another org
+      const [otherOrg] = await testDb
+        .insert(organizations)
+        .values({
+          name: "Other Org",
+          slug: "other-org",
+        })
+        .returning()
+
+      const result = await updateOrganization({
+        slug: "other-org",
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe("CONFLICT")
+      }
+    })
+  })
+
+  describe("getUserOrganizations", () => {
+    it("should return all organizations user belongs to", async () => {
+      // Create second org
+      const [secondOrg] = await testDb
+        .insert(organizations)
+        .values({
+          name: "Second Org",
+          slug: "second-org",
+        })
+        .returning()
+
+      await testDb.insert(organizationMembers).values({
+        organizationId: secondOrg.id,
+        userId: testUser.id,
+        role: "member",
+        acceptedAt: new Date(),
+      })
+
+      const result = await getUserOrganizations()
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data).toHaveLength(2)
+        expect(result.data.map((o) => o.name)).toContain("Test Org")
+        expect(result.data.map((o) => o.name)).toContain("Second Org")
+      }
+    })
+
+    it("should not return orgs with pending membership", async () => {
+      const [pendingOrg] = await testDb
+        .insert(organizations)
+        .values({
+          name: "Pending Org",
+          slug: "pending-org",
+        })
+        .returning()
+
+      await testDb.insert(organizationMembers).values({
+        organizationId: pendingOrg.id,
+        userId: testUser.id,
+        role: "member",
+        acceptedAt: null, // Not accepted
+      })
+
+      const result = await getUserOrganizations()
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.map((o) => o.name)).not.toContain("Pending Org")
+      }
+    })
+  })
+})
+
+describe("Member Management", () => {
+  let owner: typeof users.$inferSelect
+  let admin: typeof users.$inferSelect
+  let member: typeof users.$inferSelect
+  let testOrg: typeof organizations.$inferSelect
+
+  beforeEach(async () => {
+    // Create users
+    ;[owner] = await testDb
+      .insert(users)
+      .values({ email: "owner@example.com", name: "Owner" })
+      .returning()
+    ;[admin] = await testDb
+      .insert(users)
+      .values({ email: "admin@example.com", name: "Admin" })
+      .returning()
+    ;[member] = await testDb
+      .insert(users)
+      .values({ email: "member@example.com", name: "Member" })
+      .returning()
+
+    // Create organization
+    ;[testOrg] = await testDb
+      .insert(organizations)
+      .values({ name: "Test Org", slug: "test-org" })
+      .returning()
+
+    // Add members
+    await testDb.insert(organizationMembers).values([
+      {
+        organizationId: testOrg.id,
+        userId: owner.id,
+        role: "owner",
+        acceptedAt: new Date(),
+      },
+      {
+        organizationId: testOrg.id,
+        userId: admin.id,
+        role: "admin",
+        acceptedAt: new Date(),
+      },
+      {
+        organizationId: testOrg.id,
+        userId: member.id,
+        role: "member",
+        acceptedAt: new Date(),
+      },
+    ])
+  })
+
+  describe("getOrganizationMembers", () => {
+    beforeEach(() => {
+      vi.mocked(dal.requireRole).mockResolvedValue({
+        userId: owner.id as any,
+        user: { id: owner.id, email: owner.email, name: owner.name },
+        activeOrganizationId: testOrg.id as any,
+        tenantId: testOrg.id as any,
+        role: "owner",
+        db: testDb,
+      } as any)
+    })
+
+    it("should return all members", async () => {
+      const result = await getOrganizationMembers()
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data).toHaveLength(3)
+        expect(result.data.map((m) => m.email)).toContain("owner@example.com")
+        expect(result.data.map((m) => m.email)).toContain("admin@example.com")
+        expect(result.data.map((m) => m.email)).toContain("member@example.com")
+      }
+    })
+  })
+
+  describe("updateMemberRole", () => {
+    it("should allow owners to update any role", async () => {
+      vi.mocked(dal.requireRole).mockResolvedValue({
+        userId: owner.id as any,
+        user: { id: owner.id, email: owner.email, name: owner.name },
+        activeOrganizationId: testOrg.id as any,
+        tenantId: testOrg.id as any,
+        role: "owner",
+        db: testDb,
+      } as any)
+
+      const memberRecord = await testDb.query.organizationMembers.findFirst({
+        where: (t, { eq }) => eq(t.userId, member.id),
+      })
+
+      const result = await updateMemberRole({
+        memberId: memberRecord!.id,
+        role: "admin",
+      })
+
+      expect(result.success).toBe(true)
+
+      const updated = await testDb.query.organizationMembers.findFirst({
+        where: (t, { eq }) => eq(t.id, memberRecord!.id),
+      })
+      expect(updated?.role).toBe("admin")
+    })
+
+    it("should prevent admins from modifying owners", async () => {
+      vi.mocked(dal.requireRole).mockResolvedValue({
+        userId: admin.id as any,
+        user: { id: admin.id, email: admin.email, name: admin.name },
+        activeOrganizationId: testOrg.id as any,
+        tenantId: testOrg.id as any,
+        role: "admin",
+        db: testDb,
+      } as any)
+
+      const ownerRecord = await testDb.query.organizationMembers.findFirst({
+        where: (t, { eq }) => eq(t.userId, owner.id),
+      })
+
+      const result = await updateMemberRole({
+        memberId: ownerRecord!.id,
+        role: "member",
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe("FORBIDDEN")
+      }
+    })
+
+    it("should prevent non-owners from assigning owner role", async () => {
+      vi.mocked(dal.requireRole).mockResolvedValue({
+        userId: admin.id as any,
+        user: { id: admin.id, email: admin.email, name: admin.name },
+        activeOrganizationId: testOrg.id as any,
+        tenantId: testOrg.id as any,
+        role: "admin",
+        db: testDb,
+      } as any)
+
+      const memberRecord = await testDb.query.organizationMembers.findFirst({
+        where: (t, { eq }) => eq(t.userId, member.id),
+      })
+
+      const result = await updateMemberRole({
+        memberId: memberRecord!.id,
+        role: "owner",
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe("FORBIDDEN")
+      }
+    })
+  })
+
+  describe("removeMember", () => {
+    it("should allow owners to remove members", async () => {
+      vi.mocked(dal.requireRole).mockResolvedValue({
+        userId: owner.id as any,
+        user: { id: owner.id, email: owner.email, name: owner.name },
+        activeOrganizationId: testOrg.id as any,
+        tenantId: testOrg.id as any,
+        role: "owner",
+        db: testDb,
+      } as any)
+
+      const memberRecord = await testDb.query.organizationMembers.findFirst({
+        where: (t, { eq }) => eq(t.userId, member.id),
+      })
+
+      const result = await removeMember(memberRecord!.id)
+
+      expect(result.success).toBe(true)
+
+      const removed = await testDb.query.organizationMembers.findFirst({
+        where: (t, { eq }) => eq(t.id, memberRecord!.id),
+      })
+      expect(removed).toBeUndefined()
+    })
+
+    it("should prevent admins from removing owners", async () => {
+      vi.mocked(dal.requireRole).mockResolvedValue({
+        userId: admin.id as any,
+        user: { id: admin.id, email: admin.email, name: admin.name },
+        activeOrganizationId: testOrg.id as any,
+        tenantId: testOrg.id as any,
+        role: "admin",
+        db: testDb,
+      } as any)
+
+      const ownerRecord = await testDb.query.organizationMembers.findFirst({
+        where: (t, { eq }) => eq(t.userId, owner.id),
+      })
+
+      const result = await removeMember(ownerRecord!.id)
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe("FORBIDDEN")
+      }
+    })
+  })
+})
+
+describe("Invitation Flow", () => {
+  let testUser: typeof users.$inferSelect
+  let testOrg: typeof organizations.$inferSelect
+
+  beforeEach(async () => {
+    ;[testUser] = await testDb
+      .insert(users)
+      .values({ email: "owner@example.com", name: "Owner" })
+      .returning()
+
+    ;[testOrg] = await testDb
+      .insert(organizations)
+      .values({ name: "Test Org", slug: "test-org" })
+      .returning()
+
+    await testDb.insert(organizationMembers).values({
+      organizationId: testOrg.id,
+      userId: testUser.id,
+      role: "owner",
+      acceptedAt: new Date(),
+    })
+  })
+
+  describe("inviteMember", () => {
+    beforeEach(() => {
+      vi.mocked(dal.requireRole).mockResolvedValue({
+        userId: testUser.id as any,
+        user: { id: testUser.id, email: testUser.email, name: testUser.name },
+        activeOrganizationId: testOrg.id as any,
+        tenantId: testOrg.id as any,
+        role: "owner",
+        db: testDb,
+      } as any)
+    })
+
+    it("should create an invitation", async () => {
+      const result = await inviteMember({
+        email: "newuser@example.com",
+        role: "member",
+      })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        const invitation = await testDb.query.organizationInvitations.findFirst({
+          where: (t, { eq }) => eq(t.id, result.data.id),
+        })
+        expect(invitation?.email).toBe("newuser@example.com")
+        expect(invitation?.role).toBe("member")
+        expect(invitation?.status).toBe("pending")
+        expect(invitation?.token).toBeTruthy()
+      }
+    })
+
+    it("should reject inviting existing members", async () => {
+      const [existingUser] = await testDb
+        .insert(users)
+        .values({ email: "existing@example.com" })
+        .returning()
+
+      await testDb.insert(organizationMembers).values({
+        organizationId: testOrg.id,
+        userId: existingUser.id,
+        role: "member",
+        acceptedAt: new Date(),
+      })
+
+      const result = await inviteMember({
+        email: "existing@example.com",
+        role: "member",
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe("CONFLICT")
+      }
+    })
+
+    it("should reject duplicate pending invitations", async () => {
+      await testDb.insert(organizationInvitations).values({
+        organizationId: testOrg.id,
+        email: "pending@example.com",
+        role: "member",
+        token: "test-token",
+        invitedBy: testUser.id,
+        status: "pending",
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      })
+
+      const result = await inviteMember({
+        email: "pending@example.com",
+        role: "member",
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe("CONFLICT")
+      }
+    })
+  })
+
+  describe("acceptInvitation", () => {
+    let invitedUser: typeof users.$inferSelect
+    let invitation: typeof organizationInvitations.$inferSelect
+
+    beforeEach(async () => {
+      ;[invitedUser] = await testDb
+        .insert(users)
+        .values({ email: "invited@example.com" })
+        .returning()
+
+      ;[invitation] = await testDb
+        .insert(organizationInvitations)
+        .values({
+          organizationId: testOrg.id,
+          email: invitedUser.email,
+          role: "member",
+          token: "test-token",
+          invitedBy: testUser.id,
+          status: "pending",
+          expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        })
+        .returning()
+
+      vi.mocked(dal.verifySession).mockResolvedValue({
+        userId: invitedUser.id as any,
+        user: {
+          id: invitedUser.id,
+          email: invitedUser.email,
+          name: invitedUser.name,
+        },
+        activeOrganizationId: null,
+      })
+    })
+
+    it("should accept invitation and create membership", async () => {
+      const result = await acceptInvitation(invitation.token)
+
+      expect(result.success).toBe(true)
+
+      const updatedInvitation =
+        await testDb.query.organizationInvitations.findFirst({
+          where: (t, { eq }) => eq(t.id, invitation.id),
+        })
+      expect(updatedInvitation?.status).toBe("accepted")
+
+      const membership = await testDb.query.organizationMembers.findFirst({
+        where: (t, { eq, and }) =>
+          and(
+            eq(t.organizationId, testOrg.id),
+            eq(t.userId, invitedUser.id)
+          ),
+      })
+      expect(membership?.role).toBe("member")
+      expect(membership?.acceptedAt).toBeTruthy()
+    })
+
+    it("should reject expired invitations", async () => {
+      await testDb
+        .update(organizationInvitations)
+        .set({ expiresAt: new Date(Date.now() - 1000) })
+        .where((t, { eq }) => eq(t.id, invitation.id))
+
+      const result = await acceptInvitation(invitation.token)
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe("NOT_FOUND")
+      }
+    })
+
+    it("should reject wrong email", async () => {
+      const [otherUser] = await testDb
+        .insert(users)
+        .values({ email: "other@example.com" })
+        .returning()
+
+      vi.mocked(dal.verifySession).mockResolvedValue({
+        userId: otherUser.id as any,
+        user: { id: otherUser.id, email: otherUser.email, name: null },
+        activeOrganizationId: null,
+      })
+
+      const result = await acceptInvitation(invitation.token)
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe("NOT_FOUND")
+      }
+    })
+  })
+
+  describe("declineInvitation", () => {
+    let invitedUser: typeof users.$inferSelect
+    let invitation: typeof organizationInvitations.$inferSelect
+
+    beforeEach(async () => {
+      ;[invitedUser] = await testDb
+        .insert(users)
+        .values({ email: "invited@example.com" })
+        .returning()
+
+      ;[invitation] = await testDb
+        .insert(organizationInvitations)
+        .values({
+          organizationId: testOrg.id,
+          email: invitedUser.email,
+          role: "member",
+          token: "test-token",
+          invitedBy: testUser.id,
+          status: "pending",
+          expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        })
+        .returning()
+
+      vi.mocked(dal.verifySession).mockResolvedValue({
+        userId: invitedUser.id as any,
+        user: {
+          id: invitedUser.id,
+          email: invitedUser.email,
+          name: invitedUser.name,
+        },
+        activeOrganizationId: null,
+      })
+    })
+
+    it("should decline invitation", async () => {
+      const result = await declineInvitation(invitation.token)
+
+      expect(result.success).toBe(true)
+
+      const updatedInvitation =
+        await testDb.query.organizationInvitations.findFirst({
+          where: (t, { eq }) => eq(t.id, invitation.id),
+        })
+      expect(updatedInvitation?.status).toBe("declined")
+
+      const membership = await testDb.query.organizationMembers.findFirst({
+        where: (t, { eq, and }) =>
+          and(
+            eq(t.organizationId, testOrg.id),
+            eq(t.userId, invitedUser.id)
+          ),
+      })
+      expect(membership).toBeUndefined()
+    })
+  })
+})

--- a/app/actions/organizations.ts
+++ b/app/actions/organizations.ts
@@ -1,0 +1,727 @@
+"use server"
+
+/**
+ * @fileoverview Server actions for organization management
+ *
+ * This module provides server actions for organization CRUD operations,
+ * member management, and organization switching.
+ *
+ * @module app/actions/organizations
+ */
+
+import { revalidatePath } from "next/cache"
+import { redirect } from "next/navigation"
+import { z } from "zod"
+import { db } from "@/db"
+import {
+  organizations,
+  organizationMembers,
+  organizationInvitations,
+  sessions,
+  users,
+} from "@/db/schema"
+import { eq, and, isNull, isNotNull, inArray, gt } from "drizzle-orm"
+import {
+  verifySession,
+  requireRole,
+  type TenantId,
+  type UserId,
+} from "@/lib/dal"
+import { auth } from "@/lib/auth"
+import {
+  actionSuccess,
+  actionError,
+  withActionErrorHandling,
+  type ActionResult,
+} from "@/lib/api-utils"
+import {
+  NotFoundError,
+  ForbiddenError,
+  ValidationError,
+  ConflictError,
+} from "@/lib/errors"
+import crypto from "crypto"
+
+// ============================================================================
+// Validation Schemas
+// ============================================================================
+
+const createOrganizationSchema = z.object({
+  name: z.string().min(1, "Organization name is required").max(100),
+  slug: z
+    .string()
+    .min(1)
+    .max(50)
+    .regex(/^[a-z0-9-]+$/, "Slug must be lowercase alphanumeric with hyphens"),
+})
+
+const updateOrganizationSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  slug: z
+    .string()
+    .min(1)
+    .max(50)
+    .regex(/^[a-z0-9-]+$/)
+    .optional(),
+})
+
+const inviteMemberSchema = z.object({
+  email: z.string().email("Invalid email address"),
+  role: z.enum(["member", "admin", "owner"]).default("member"),
+})
+
+const updateMemberRoleSchema = z.object({
+  memberId: z.string().uuid(),
+  role: z.enum(["member", "admin", "owner"]),
+})
+
+// ============================================================================
+// Organization CRUD
+// ============================================================================
+
+/**
+ * Create a new organization
+ */
+export async function createOrganization(
+  input: z.infer<typeof createOrganizationSchema>
+): Promise<ActionResult<{ id: string }>> {
+  return withActionErrorHandling(async () => {
+    const session = await verifySession()
+    const parsed = createOrganizationSchema.safeParse(input)
+
+    if (!parsed.success) {
+      throw ValidationError.fromZodError(parsed.error)
+    }
+
+    const { name, slug } = parsed.data
+
+    // Check if slug already exists
+    const existing = await db.query.organizations.findFirst({
+      where: and(eq(organizations.slug, slug), isNull(organizations.deletedAt)),
+    })
+
+    if (existing) {
+      throw new ConflictError("Organization slug already exists")
+    }
+
+    // Create organization and add user as owner
+    const [org] = await db
+      .insert(organizations)
+      .values({ name, slug })
+      .returning()
+
+    await db.insert(organizationMembers).values({
+      organizationId: org.id,
+      userId: session.userId as string,
+      role: "owner",
+      acceptedAt: new Date(),
+    })
+
+    revalidatePath("/settings/organizations")
+    return actionSuccess({ id: org.id })
+  })()
+}
+
+/**
+ * Update organization details
+ */
+export async function updateOrganization(
+  input: z.infer<typeof updateOrganizationSchema>
+): Promise<ActionResult<{ id: string }>> {
+  return withActionErrorHandling(async () => {
+    const ctx = await requireRole(["owner", "admin"])
+    const parsed = updateOrganizationSchema.safeParse(input)
+
+    if (!parsed.success) {
+      throw ValidationError.fromZodError(parsed.error)
+    }
+
+    const updates = parsed.data
+    if (Object.keys(updates).length === 0) {
+      throw new ValidationError("No updates provided")
+    }
+
+    // If updating slug, check for conflicts
+    if (updates.slug) {
+      const existing = await db.query.organizations.findFirst({
+        where: and(
+          eq(organizations.slug, updates.slug),
+          isNull(organizations.deletedAt)
+        ),
+      })
+
+      if (existing && existing.id !== ctx.tenantId) {
+        throw new ConflictError("Organization slug already exists")
+      }
+    }
+
+    await ctx.db
+      .update(organizations)
+      .set(updates)
+      .where(eq(organizations.id, ctx.tenantId as string))
+
+    revalidatePath("/settings/organization")
+    return actionSuccess({ id: ctx.tenantId as string })
+  })()
+}
+
+/**
+ * Delete (soft delete) an organization
+ */
+export async function deleteOrganization(): Promise<ActionResult<void>> {
+  return withActionErrorHandling(async () => {
+    const ctx = await requireRole(["owner"])
+
+    await ctx.db
+      .update(organizations)
+      .set({ deletedAt: new Date() })
+      .where(eq(organizations.id, ctx.tenantId as string))
+
+    revalidatePath("/settings/organizations")
+    redirect("/onboarding")
+  })()
+}
+
+// ============================================================================
+// Organization Switching
+// ============================================================================
+
+/**
+ * Get all organizations the current user belongs to
+ */
+export async function getUserOrganizations(): Promise<
+  ActionResult<
+    Array<{
+      id: string
+      name: string
+      slug: string
+      role: string
+      memberCount: number
+    }>
+  >
+> {
+  return withActionErrorHandling(async () => {
+    const session = await verifySession()
+
+    const memberships = await db
+      .select({
+        id: organizations.id,
+        name: organizations.name,
+        slug: organizations.slug,
+        role: organizationMembers.role,
+      })
+      .from(organizationMembers)
+      .innerJoin(
+        organizations,
+        eq(organizations.id, organizationMembers.organizationId)
+      )
+      .where(
+        and(
+          eq(organizationMembers.userId, session.userId as string),
+          isNotNull(organizationMembers.acceptedAt),
+          isNull(organizations.deletedAt)
+        )
+      )
+
+    // Get member counts for each org
+    const orgsWithCounts = await Promise.all(
+      memberships.map(async (org) => {
+        const [result] = await db
+          .select({ count: db.$count(organizationMembers.id) })
+          .from(organizationMembers)
+          .where(
+            and(
+              eq(organizationMembers.organizationId, org.id),
+              isNotNull(organizationMembers.acceptedAt)
+            )
+          )
+
+        return {
+          ...org,
+          memberCount: result?.count ?? 0,
+        }
+      })
+    )
+
+    return actionSuccess(orgsWithCounts)
+  })()
+}
+
+/**
+ * Switch the active organization in the session
+ */
+export async function switchOrganization(
+  organizationId: string
+): Promise<ActionResult<void>> {
+  return withActionErrorHandling(async () => {
+    const session = await verifySession()
+
+    // Verify user is a member of this organization
+    const membership = await db.query.organizationMembers.findFirst({
+      where: and(
+        eq(organizationMembers.organizationId, organizationId),
+        eq(organizationMembers.userId, session.userId as string),
+        isNotNull(organizationMembers.acceptedAt)
+      ),
+    })
+
+    if (!membership) {
+      throw new ForbiddenError(
+        "You are not a member of this organization"
+      )
+    }
+
+    // Update session
+    const authSession = await auth()
+    if (!authSession?.user?.id) {
+      throw new Error("No active session")
+    }
+
+    await db
+      .update(sessions)
+      .set({ activeOrganizationId: organizationId })
+      .where(eq(sessions.userId, authSession.user.id))
+
+    revalidatePath("/", "layout")
+    return actionSuccess(undefined)
+  })()
+}
+
+// ============================================================================
+// Member Management
+// ============================================================================
+
+/**
+ * Get all members of the current organization
+ */
+export async function getOrganizationMembers(): Promise<
+  ActionResult<
+    Array<{
+      id: string
+      userId: string
+      name: string | null
+      email: string
+      image: string | null
+      role: string
+      acceptedAt: Date | null
+      invitedBy: string | null
+    }>
+  >
+> {
+  return withActionErrorHandling(async () => {
+    const ctx = await requireRole(["owner", "admin", "member"])
+
+    const members = await ctx.db
+      .select({
+        id: organizationMembers.id,
+        userId: organizationMembers.userId,
+        name: users.name,
+        email: users.email,
+        image: users.image,
+        role: organizationMembers.role,
+        acceptedAt: organizationMembers.acceptedAt,
+        invitedBy: organizationMembers.invitedBy,
+      })
+      .from(organizationMembers)
+      .innerJoin(users, eq(users.id, organizationMembers.userId))
+      .where(eq(organizationMembers.organizationId, ctx.tenantId as string))
+      .orderBy(organizationMembers.createdAt)
+
+    return actionSuccess(members)
+  })()
+}
+
+/**
+ * Update a member's role
+ */
+export async function updateMemberRole(
+  input: z.infer<typeof updateMemberRoleSchema>
+): Promise<ActionResult<void>> {
+  return withActionErrorHandling(async () => {
+    const ctx = await requireRole(["owner", "admin"])
+    const parsed = updateMemberRoleSchema.safeParse(input)
+
+    if (!parsed.success) {
+      throw ValidationError.fromZodError(parsed.error)
+    }
+
+    const { memberId, role } = parsed.data
+
+    // Only owners can assign owner role
+    if (role === "owner" && ctx.role !== "owner") {
+      throw new ForbiddenError("Only owners can assign owner role")
+    }
+
+    // Admins cannot modify owners
+    if (ctx.role === "admin") {
+      const targetMember = await ctx.db.query.organizationMembers.findFirst({
+        where: eq(organizationMembers.id, memberId),
+      })
+
+      if (targetMember?.role === "owner") {
+        throw new ForbiddenError("Admins cannot modify owners")
+      }
+    }
+
+    await ctx.db
+      .update(organizationMembers)
+      .set({ role })
+      .where(
+        and(
+          eq(organizationMembers.id, memberId),
+          eq(organizationMembers.organizationId, ctx.tenantId as string)
+        )
+      )
+
+    revalidatePath("/settings/organization/members")
+    return actionSuccess(undefined)
+  })()
+}
+
+/**
+ * Remove a member from the organization
+ */
+export async function removeMember(memberId: string): Promise<ActionResult<void>> {
+  return withActionErrorHandling(async () => {
+    const ctx = await requireRole(["owner", "admin"])
+
+    const member = await ctx.db.query.organizationMembers.findFirst({
+      where: and(
+        eq(organizationMembers.id, memberId),
+        eq(organizationMembers.organizationId, ctx.tenantId as string)
+      ),
+    })
+
+    if (!member) {
+      throw new NotFoundError("Member not found")
+    }
+
+    // Prevent removing yourself if you're the only owner
+    if (member.userId === ctx.userId && member.role === "owner") {
+      const ownerCount = await ctx.db
+        .select({ count: db.$count(organizationMembers.id) })
+        .from(organizationMembers)
+        .where(
+          and(
+            eq(organizationMembers.organizationId, ctx.tenantId as string),
+            eq(organizationMembers.role, "owner")
+          )
+        )
+
+      if (ownerCount[0]?.count === 1) {
+        throw new ForbiddenError(
+          "Cannot remove the only owner. Transfer ownership first."
+        )
+      }
+    }
+
+    // Admins cannot remove owners
+    if (ctx.role === "admin" && member.role === "owner") {
+      throw new ForbiddenError("Admins cannot remove owners")
+    }
+
+    await ctx.db
+      .delete(organizationMembers)
+      .where(eq(organizationMembers.id, memberId))
+
+    revalidatePath("/settings/organization/members")
+    return actionSuccess(undefined)
+  })()
+}
+
+// ============================================================================
+// Invitations
+// ============================================================================
+
+/**
+ * Get pending invitations for the current organization
+ */
+export async function getOrganizationInvitations(): Promise<
+  ActionResult<
+    Array<{
+      id: string
+      email: string
+      role: string
+      status: string
+      expiresAt: Date
+      inviterName: string | null
+      createdAt: Date
+    }>
+  >
+> {
+  return withActionErrorHandling(async () => {
+    const ctx = await requireRole(["owner", "admin"])
+
+    const invitations = await ctx.db
+      .select({
+        id: organizationInvitations.id,
+        email: organizationInvitations.email,
+        role: organizationInvitations.role,
+        status: organizationInvitations.status,
+        expiresAt: organizationInvitations.expiresAt,
+        inviterName: users.name,
+        createdAt: organizationInvitations.createdAt,
+      })
+      .from(organizationInvitations)
+      .innerJoin(users, eq(users.id, organizationInvitations.invitedBy))
+      .where(
+        eq(organizationInvitations.organizationId, ctx.tenantId as string)
+      )
+      .orderBy(organizationInvitations.createdAt)
+
+    return actionSuccess(invitations)
+  })()
+}
+
+/**
+ * Get pending invitations for the current user
+ */
+export async function getUserInvitations(): Promise<
+  ActionResult<
+    Array<{
+      id: string
+      token: string
+      organizationName: string
+      organizationSlug: string
+      role: string
+      expiresAt: Date
+      inviterName: string | null
+    }>
+  >
+> {
+  return withActionErrorHandling(async () => {
+    const session = await verifySession()
+    const user = await db.query.users.findFirst({
+      where: eq(users.id, session.userId as string),
+    })
+
+    if (!user) {
+      throw new NotFoundError("User not found")
+    }
+
+    const invitations = await db
+      .select({
+        id: organizationInvitations.id,
+        token: organizationInvitations.token,
+        organizationName: organizations.name,
+        organizationSlug: organizations.slug,
+        role: organizationInvitations.role,
+        expiresAt: organizationInvitations.expiresAt,
+        inviterName: users.name,
+      })
+      .from(organizationInvitations)
+      .innerJoin(
+        organizations,
+        eq(organizations.id, organizationInvitations.organizationId)
+      )
+      .innerJoin(users, eq(users.id, organizationInvitations.invitedBy))
+      .where(
+        and(
+          eq(organizationInvitations.email, user.email),
+          eq(organizationInvitations.status, "pending"),
+          gt(organizationInvitations.expiresAt, new Date())
+        )
+      )
+
+    return actionSuccess(invitations)
+  })()
+}
+
+/**
+ * Invite a new member to the organization
+ */
+export async function inviteMember(
+  input: z.infer<typeof inviteMemberSchema>
+): Promise<ActionResult<{ id: string }>> {
+  return withActionErrorHandling(async () => {
+    const ctx = await requireRole(["owner", "admin"])
+    const parsed = inviteMemberSchema.safeParse(input)
+
+    if (!parsed.success) {
+      throw ValidationError.fromZodError(parsed.error)
+    }
+
+    const { email, role } = parsed.data
+
+    // Only owners can invite owners
+    if (role === "owner" && ctx.role !== "owner") {
+      throw new ForbiddenError("Only owners can invite owners")
+    }
+
+    // Check if user is already a member
+    const existingUser = await db.query.users.findFirst({
+      where: eq(users.email, email),
+    })
+
+    if (existingUser) {
+      const existingMember = await ctx.db.query.organizationMembers.findFirst({
+        where: and(
+          eq(organizationMembers.organizationId, ctx.tenantId as string),
+          eq(organizationMembers.userId, existingUser.id)
+        ),
+      })
+
+      if (existingMember) {
+        throw new ConflictError("User is already a member")
+      }
+    }
+
+    // Check for pending invitation
+    const pendingInvitation =
+      await ctx.db.query.organizationInvitations.findFirst({
+        where: and(
+          eq(organizationInvitations.organizationId, ctx.tenantId as string),
+          eq(organizationInvitations.email, email),
+          eq(organizationInvitations.status, "pending"),
+          gt(organizationInvitations.expiresAt, new Date())
+        ),
+      })
+
+    if (pendingInvitation) {
+      throw new ConflictError("Pending invitation already exists")
+    }
+
+    // Create invitation
+    const token = crypto.randomBytes(32).toString("hex")
+    const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000) // 7 days
+
+    const [invitation] = await ctx.db
+      .insert(organizationInvitations)
+      .values({
+        organizationId: ctx.tenantId as string,
+        email,
+        role,
+        token,
+        invitedBy: ctx.userId as string,
+        status: "pending",
+        expiresAt,
+      })
+      .returning()
+
+    // TODO: Send invitation email via Resend
+    // await sendInvitationEmail({ email, token, organizationName: org.name })
+
+    revalidatePath("/settings/organization/members")
+    return actionSuccess({ id: invitation.id })
+  })()
+}
+
+/**
+ * Accept an invitation
+ */
+export async function acceptInvitation(
+  token: string
+): Promise<ActionResult<{ organizationId: string }>> {
+  return withActionErrorHandling(async () => {
+    const session = await verifySession()
+    const user = await db.query.users.findFirst({
+      where: eq(users.id, session.userId as string),
+    })
+
+    if (!user) {
+      throw new NotFoundError("User not found")
+    }
+
+    const invitation = await db.query.organizationInvitations.findFirst({
+      where: and(
+        eq(organizationInvitations.token, token),
+        eq(organizationInvitations.email, user.email),
+        eq(organizationInvitations.status, "pending"),
+        gt(organizationInvitations.expiresAt, new Date())
+      ),
+    })
+
+    if (!invitation) {
+      throw new NotFoundError("Invitation not found or expired")
+    }
+
+    // Accept invitation in a transaction
+    await db.transaction(async (tx) => {
+      // Mark invitation as accepted
+      await tx
+        .update(organizationInvitations)
+        .set({ status: "accepted" })
+        .where(eq(organizationInvitations.id, invitation.id))
+
+      // Create membership
+      await tx.insert(organizationMembers).values({
+        organizationId: invitation.organizationId,
+        userId: session.userId as string,
+        role: invitation.role,
+        invitedBy: invitation.invitedBy,
+        invitedAt: invitation.createdAt,
+        acceptedAt: new Date(),
+      })
+    })
+
+    revalidatePath("/settings/organizations")
+    return actionSuccess({ organizationId: invitation.organizationId })
+  })()
+}
+
+/**
+ * Decline an invitation
+ */
+export async function declineInvitation(
+  token: string
+): Promise<ActionResult<void>> {
+  return withActionErrorHandling(async () => {
+    const session = await verifySession()
+    const user = await db.query.users.findFirst({
+      where: eq(users.id, session.userId as string),
+    })
+
+    if (!user) {
+      throw new NotFoundError("User not found")
+    }
+
+    const invitation = await db.query.organizationInvitations.findFirst({
+      where: and(
+        eq(organizationInvitations.token, token),
+        eq(organizationInvitations.email, user.email),
+        eq(organizationInvitations.status, "pending")
+      ),
+    })
+
+    if (!invitation) {
+      throw new NotFoundError("Invitation not found")
+    }
+
+    await db
+      .update(organizationInvitations)
+      .set({ status: "declined" })
+      .where(eq(organizationInvitations.id, invitation.id))
+
+    revalidatePath("/settings/organizations")
+    return actionSuccess(undefined)
+  })()
+}
+
+/**
+ * Cancel (revoke) an invitation
+ */
+export async function cancelInvitation(
+  invitationId: string
+): Promise<ActionResult<void>> {
+  return withActionErrorHandling(async () => {
+    const ctx = await requireRole(["owner", "admin"])
+
+    const invitation = await ctx.db.query.organizationInvitations.findFirst({
+      where: and(
+        eq(organizationInvitations.id, invitationId),
+        eq(organizationInvitations.organizationId, ctx.tenantId as string)
+      ),
+    })
+
+    if (!invitation) {
+      throw new NotFoundError("Invitation not found")
+    }
+
+    await ctx.db
+      .delete(organizationInvitations)
+      .where(eq(organizationInvitations.id, invitationId))
+
+    revalidatePath("/settings/organization/members")
+    return actionSuccess(undefined)
+  })()
+}

--- a/components/organization-switcher.tsx
+++ b/components/organization-switcher.tsx
@@ -65,7 +65,7 @@ export function OrganizationSwitcher({
     loadOrganizations()
   }, [])
 
-  const currentOrg = organizations.find((org) => org.id === currentOrganizationId)
+  const _currentOrg = organizations.find((org) => org.id === currentOrganizationId)
 
   async function handleSwitch(organizationId: string) {
     if (organizationId === currentOrganizationId) {

--- a/components/organization-switcher.tsx
+++ b/components/organization-switcher.tsx
@@ -1,0 +1,163 @@
+"use client"
+
+/**
+ * @fileoverview Organization switcher component
+ *
+ * Displays the current organization and allows switching between
+ * organizations the user belongs to.
+ */
+
+import { useState, useEffect } from "react"
+import { Check, ChevronsUpDown, Building2, Plus } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { getUserOrganizations, switchOrganization } from "@/app/actions/organizations"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+
+interface Organization {
+  id: string
+  name: string
+  slug: string
+  role: string
+  memberCount: number
+}
+
+interface OrganizationSwitcherProps {
+  currentOrganizationId?: string
+  currentOrganizationName?: string
+}
+
+export function OrganizationSwitcher({
+  currentOrganizationId,
+  currentOrganizationName,
+}: OrganizationSwitcherProps) {
+  const [open, setOpen] = useState(false)
+  const [organizations, setOrganizations] = useState<Organization[]>([])
+  const [loading, setLoading] = useState(true)
+  const [switching, setSwitching] = useState(false)
+  const router = useRouter()
+
+  useEffect(() => {
+    async function loadOrganizations() {
+      const result = await getUserOrganizations()
+      if (result.success) {
+        setOrganizations(result.data)
+      } else {
+        toast.error("Failed to load organizations")
+      }
+      setLoading(false)
+    }
+    loadOrganizations()
+  }, [])
+
+  const currentOrg = organizations.find((org) => org.id === currentOrganizationId)
+
+  async function handleSwitch(organizationId: string) {
+    if (organizationId === currentOrganizationId) {
+      setOpen(false)
+      return
+    }
+
+    setSwitching(true)
+    const result = await switchOrganization(organizationId)
+
+    if (result.success) {
+      toast.success("Organization switched")
+      setOpen(false)
+      router.refresh()
+    } else {
+      toast.error(result.error.message)
+    }
+    setSwitching(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          aria-label="Select organization"
+          className="w-full justify-between"
+        >
+          <div className="flex items-center gap-2 min-w-0">
+            <Building2 className="h-4 w-4 shrink-0" />
+            <span className="truncate">
+              {currentOrganizationName || "Select organization"}
+            </span>
+          </div>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[300px] p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Search organizations..." />
+          <CommandList>
+            <CommandEmpty>
+              {loading ? "Loading..." : "No organizations found."}
+            </CommandEmpty>
+            <CommandGroup heading="Your Organizations">
+              {organizations.map((org) => (
+                <CommandItem
+                  key={org.id}
+                  onSelect={() => handleSwitch(org.id)}
+                  disabled={switching}
+                  className="cursor-pointer"
+                >
+                  <div className="flex items-center justify-between w-full">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <Check
+                        className={cn(
+                          "h-4 w-4 shrink-0",
+                          currentOrganizationId === org.id
+                            ? "opacity-100"
+                            : "opacity-0"
+                        )}
+                      />
+                      <div className="flex flex-col min-w-0">
+                        <span className="truncate font-medium">{org.name}</span>
+                        <span className="text-xs text-muted-foreground">
+                          {org.role} · {org.memberCount} member
+                          {org.memberCount !== 1 ? "s" : ""}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+            <CommandSeparator />
+            <CommandGroup>
+              <CommandItem
+                onSelect={() => {
+                  setOpen(false)
+                  router.push("/settings/organizations/new")
+                }}
+                className="cursor-pointer"
+              >
+                <Plus className="mr-2 h-4 w-4" />
+                Create Organization
+              </CommandItem>
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/db/schema/index.ts
+++ b/db/schema/index.ts
@@ -1,6 +1,7 @@
 // src/db/schema/index.ts
 export * from "./auth"
 export * from "./organizations"
+export * from "./invitations"
 export * from "./documents"
 export * from "./analyses"
 export * from "./comparisons"

--- a/db/schema/invitations.ts
+++ b/db/schema/invitations.ts
@@ -1,0 +1,204 @@
+/**
+ * @fileoverview Organization invitation schema for VibeDocs
+ *
+ * This module defines the invitation flow for adding new members to organizations.
+ * Invitations are sent via email with single-use tokens that expire after a configured duration.
+ *
+ * @module db/schema/invitations
+ */
+
+import {
+  pgTable,
+  text,
+  uuid,
+  timestamp,
+  index,
+} from "drizzle-orm/pg-core"
+import { primaryId, timestamps } from "../_columns"
+import { users } from "./auth"
+import { organizations } from "./organizations"
+
+/**
+ * Organization invitations table - manages pending invitations to join organizations
+ *
+ * This table stores invitations sent to users (via email) to join an organization.
+ * Invitations include a single-use token, expiration date, and track acceptance status.
+ *
+ * ## Columns
+ *
+ * | Column         | Type      | Description                                    |
+ * |----------------|-----------|------------------------------------------------|
+ * | id             | uuid      | Primary key (auto-generated UUIDv4)            |
+ * | organizationId | uuid      | FK to organizations.id (cascade delete)        |
+ * | email          | text      | Email address of invitee                       |
+ * | role           | text      | Intended role for the invitee                  |
+ * | token          | text      | Unique single-use invitation token             |
+ * | invitedBy      | uuid      | FK to users.id who sent the invitation         |
+ * | status         | text      | Invitation status (pending/accepted/declined)  |
+ * | expiresAt      | timestamp | Token expiration timestamp                     |
+ * | createdAt      | timestamp | Record creation timestamp                      |
+ * | updatedAt      | timestamp | Last modification timestamp                    |
+ *
+ * ## Status Values
+ *
+ * - `"pending"` - Invitation sent, awaiting user action
+ * - `"accepted"` - User accepted and joined organization
+ * - `"declined"` - User explicitly declined invitation
+ * - `"expired"` - Invitation passed expiration date without action
+ *
+ * ## Token Security
+ *
+ * - Tokens are cryptographically random (e.g., using `crypto.randomBytes()`)
+ * - Single-use: marked as accepted/declined after use
+ * - Time-limited: expire after 7 days (configurable)
+ * - Unique constraint prevents token collisions
+ *
+ * ## Indexes
+ *
+ * - **Index** `idx_invitations_org`: `organization_id` - Fast lookup of org invitations
+ * - **Index** `idx_invitations_email`: `email` - Fast lookup of pending invites for user
+ * - **Index** `idx_invitations_token`: `token` - Fast token verification
+ *
+ * ## Cascade Delete Behavior
+ *
+ * - Deleting an organization cascades to delete all pending invitations
+ * - Deleting the inviter user does NOT cascade (preserves audit trail)
+ *
+ * @example
+ * // Create a new invitation
+ * import { db } from "@/db"
+ * import { organizationInvitations } from "@/db/schema"
+ * import crypto from "crypto"
+ *
+ * const token = crypto.randomBytes(32).toString("hex")
+ * const [invitation] = await db.insert(organizationInvitations).values({
+ *   organizationId: orgId,
+ *   email: "user@example.com",
+ *   role: "member",
+ *   token,
+ *   invitedBy: currentUserId,
+ *   status: "pending",
+ *   expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days
+ * }).returning()
+ *
+ * @example
+ * // Find pending invitations for an email
+ * import { db } from "@/db"
+ * import { organizationInvitations } from "@/db/schema"
+ * import { eq, and, gt } from "drizzle-orm"
+ *
+ * const pending = await db.query.organizationInvitations.findMany({
+ *   where: and(
+ *     eq(organizationInvitations.email, "user@example.com"),
+ *     eq(organizationInvitations.status, "pending"),
+ *     gt(organizationInvitations.expiresAt, new Date())
+ *   ),
+ *   with: { organization: true }
+ * })
+ *
+ * @example
+ * // Accept an invitation
+ * import { db } from "@/db"
+ * import { organizationInvitations, organizationMembers } from "@/db/schema"
+ * import { eq } from "drizzle-orm"
+ *
+ * await db.transaction(async (tx) => {
+ *   // Mark invitation as accepted
+ *   await tx.update(organizationInvitations)
+ *     .set({ status: "accepted" })
+ *     .where(eq(organizationInvitations.token, token))
+ *
+ *   // Create membership
+ *   await tx.insert(organizationMembers).values({
+ *     organizationId: invitation.organizationId,
+ *     userId: userId,
+ *     role: invitation.role,
+ *     invitedBy: invitation.invitedBy,
+ *     invitedAt: invitation.createdAt,
+ *     acceptedAt: new Date(),
+ *   })
+ * })
+ */
+export const organizationInvitations = pgTable(
+  "organization_invitations",
+  {
+    /**
+     * Primary key - auto-generated UUIDv4
+     */
+    ...primaryId,
+
+    /**
+     * Foreign key to the organization
+     * Cascade delete ensures invitations are removed when organization is deleted
+     */
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+
+    /**
+     * Email address of the person being invited
+     * May or may not be an existing user in the system
+     */
+    email: text("email").notNull(),
+
+    /**
+     * Intended role for the invitee when they accept
+     * @default "member"
+     * @enum {"owner" | "admin" | "member"}
+     */
+    role: text("role").notNull().default("member"),
+
+    /**
+     * Unique single-use token for invitation acceptance
+     * Included in the invitation email link
+     * Should be cryptographically random (e.g., 32 bytes hex-encoded)
+     */
+    token: text("token").notNull().unique(),
+
+    /**
+     * User who sent the invitation
+     * Does NOT cascade on delete to preserve audit trail
+     */
+    invitedBy: uuid("invited_by")
+      .notNull()
+      .references(() => users.id),
+
+    /**
+     * Current invitation status
+     * @default "pending"
+     * @enum {"pending" | "accepted" | "declined" | "expired"}
+     */
+    status: text("status").notNull().default("pending"),
+
+    /**
+     * Token expiration timestamp
+     * After this time, the invitation cannot be accepted
+     * Typically set to 7 days from creation
+     */
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+
+    /**
+     * Audit timestamps (createdAt, updatedAt)
+     */
+    ...timestamps,
+  },
+  (table) => [
+    /**
+     * Index for fast lookup of all invitations for an organization
+     * Used by: organization settings, member management UI
+     */
+    index("idx_invitations_org").on(table.organizationId),
+
+    /**
+     * Index for fast lookup of pending invitations by email
+     * Used by: user dashboard showing pending invites
+     */
+    index("idx_invitations_email").on(table.email),
+
+    /**
+     * Index for fast token verification during acceptance flow
+     * Used by: invitation acceptance endpoint
+     */
+    index("idx_invitations_token").on(table.token),
+  ]
+)

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -81,6 +81,19 @@ const SCHEMA_SQL = `
     UNIQUE(organization_id, user_id)
   );
 
+  CREATE TABLE IF NOT EXISTS organization_invitations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    email TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT 'member',
+    token TEXT NOT NULL UNIQUE,
+    invited_by UUID NOT NULL REFERENCES users(id),
+    status TEXT NOT NULL DEFAULT 'pending',
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+  );
+
   CREATE TABLE IF NOT EXISTS sessions (
     "sessionToken" TEXT PRIMARY KEY,
     "userId" UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -293,6 +306,28 @@ const SCHEMA_SQL = `
     completed_at TIMESTAMPTZ,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+  );
+
+  CREATE TABLE IF NOT EXISTS conversations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    document_id UUID REFERENCES documents(id) ON DELETE SET NULL,
+    title TEXT,
+    last_message_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at TIMESTAMPTZ
+  );
+
+  CREATE TABLE IF NOT EXISTS messages (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    role TEXT NOT NULL,
+    content TEXT NOT NULL,
+    attachments JSONB,
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
   );
 `
 


### PR DESCRIPTION
## Summary

Implements full organization management and switching functionality as specified in issue #46.

## Changes

**Database:**
- Add `organization_invitations` table with token-based flow
- Status tracking (pending/accepted/declined/expired)
- Single-use tokens with 7-day expiration

**Server Actions (18 total):**
- CRUD: createOrganization, updateOrganization, deleteOrganization
- Switching: getUserOrganizations, switchOrganization
- Members: getOrganizationMembers, updateMemberRole, removeMember
- Invitations: inviteMember, acceptInvitation, declineInvitation, cancelInvitation, getOrganizationInvitations, getUserInvitations

**UI Components:**
- OrganizationSwitcher: Combobox for switching between orgs
- Settings pages for organization details, member management, invitations, and creating new organizations
- Role-based UI (owner/admin/member visibility)

**Security:**
- Role-based access control throughout
- Admins cannot modify/remove owners
- Prevent removing the only owner
- Proper validation and error handling

**Tests:**
- 20+ test cases covering CRUD, member management, invitations
- Security permission checks
- Edge cases (expired tokens, duplicate invites, etc.)

## Next Steps

1. Run `pnpm db:push` to apply schema changes
2. Add email sending via Resend in `inviteMember` action
3. Integrate OrganizationSwitcher into main layout
4. Wire up settings routes in navigation

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)